### PR TITLE
Allow specifying list of environment variables.

### DIFF
--- a/air_example.conf
+++ b/air_example.conf
@@ -10,8 +10,11 @@ tmp_dir = "tmp"
 cmd = "go build -o ./tmp/main ."
 # Binary file yields from `cmd`.
 bin = "tmp/main"
-# Customize binary.
+# Customize binary.  Overrides env.
 full_bin = "APP_ENV=dev APP_USER=air ./tmp/main"
+# Provide environment variables to binary.
+# env.APP_VAR = "myval"
+# env.APP_VAR2 = "myval2"
 # Watch these filename extensions.
 include_ext = ["go", "tpl", "tmpl", "html"]
 # Ignore these filename extensions or directories.

--- a/runner/config.go
+++ b/runner/config.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -25,16 +26,17 @@ type config struct {
 }
 
 type cfgBuild struct {
-	Cmd         string   `toml:"cmd"`
-	Bin         string   `toml:"bin"`
-	FullBin     string   `toml:"full_bin"`
-	Log         string   `toml:"log"`
-	IncludeExt  []string `toml:"include_ext"`
-	ExcludeDir  []string `toml:"exclude_dir"`
-	IncludeDir  []string `toml:"include_dir"`
-	ExcludeFile []string `toml:"exclude_file"`
-	Delay       int      `toml:"delay"`
-	StopOnError bool     `toml:"stop_on_error"`
+	Cmd         string            `toml:"cmd"`
+	Bin         string            `toml:"bin"`
+	FullBin     string            `toml:"full_bin"`
+	Env         map[string]string `toml:"env"`
+	Log         string            `toml:"log"`
+	IncludeExt  []string          `toml:"include_ext"`
+	ExcludeDir  []string          `toml:"exclude_dir"`
+	IncludeDir  []string          `toml:"include_dir"`
+	ExcludeFile []string          `toml:"exclude_file"`
+	Delay       int               `toml:"delay"`
+	StopOnError bool              `toml:"stop_on_error"`
 }
 
 type cfgLog struct {
@@ -191,6 +193,13 @@ func (c *config) preprocess() error {
 	c.Build.ExcludeDir = ed
 	if len(c.Build.FullBin) > 0 {
 		c.Build.Bin = c.Build.FullBin
+		return err
+	} else if len(c.Build.Env) > 0 {
+		env := ""
+		for k, v := range c.Build.Env {
+			env = fmt.Sprintf("%s=%s %s", k, v, env)
+		}
+		c.Build.Bin = env + c.Build.Bin
 		return err
 	}
 	// Fix windows CMD processor


### PR DESCRIPTION
Thanks for the great project.  I've recently come across a case where I have many environment variables I'd like to provide to the binary and listing them all inline with the `full_bin` key was becoming a bit unwieldy.

This PR adds a new key, `env`, which will accept a table of inputs to prepend to the bin command as environment variables.

For example, this config (truncated):

```toml
# air.conf
[build]
bin = "tmp/main"
env.PORT = "3000"
env.ENV = "production"
```

Will run the following:
```
PORT=3000 ENV=production tmp/main
```