### PR TITLE
:sparkles: Added support for custom shell

### DIFF
--- a/runner/config.go
+++ b/runner/config.go
@@ -28,6 +28,7 @@ type config struct {
 
 type cfgBuild struct {
 	Cmd           string        `toml:"cmd"`
+	Shell         string        `toml:"shell"`
 	Bin           string        `toml:"bin"`
 	FullBin       string        `toml:"full_bin"`
 	Log           string        `toml:"log"`
@@ -86,6 +87,7 @@ func initConfig(path string) (cfg *config, err error) {
 func defaultConfig() config {
 	build := cfgBuild{
 		Cmd:         "go build -o ./tmp/main .",
+		Shell:       "sh",
 		Bin:         "./tmp/main",
 		Log:         "build-errors.log",
 		IncludeExt:  []string{"go", "tpl", "tmpl", "html"},
@@ -160,18 +162,18 @@ func (c *config) preprocess() error {
 		runName := "start"
 		extName := ".exe"
 		originBin := c.Build.Bin
-		if ! strings.HasSuffix(c.Build.Bin, extName) {
+		if !strings.HasSuffix(c.Build.Bin, extName) {
 
 			c.Build.Bin += extName
 		}
 
 		if 0 < len(c.Build.FullBin) {
 
-			if ! strings.HasSuffix(c.Build.FullBin, extName) {
+			if !strings.HasSuffix(c.Build.FullBin, extName) {
 
 				c.Build.FullBin += extName
 			}
-			if ! strings.HasPrefix(c.Build.FullBin, runName) {
+			if !strings.HasPrefix(c.Build.FullBin, runName) {
 				c.Build.FullBin = runName + " " + c.Build.FullBin
 			}
 		}
@@ -181,7 +183,6 @@ func (c *config) preprocess() error {
 			c.Build.Cmd = strings.Replace(c.Build.Cmd, originBin, c.Build.Bin, 1)
 		}
 	}
-
 
 	c.Build.ExcludeDir = ed
 	if len(c.Build.FullBin) > 0 {

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -269,7 +269,7 @@ func (e *Engine) flushEvents() {
 func (e *Engine) building() error {
 	var err error
 	e.buildLog("building...")
-	cmd, stdout, stderr, err := e.startCmd(e.config.Build.Cmd)
+	cmd, stdout, stderr, err := e.startCmd(e.config.Build.Shell, e.config.Build.Cmd)
 	if err != nil {
 		return err
 	}
@@ -290,7 +290,7 @@ func (e *Engine) building() error {
 func (e *Engine) runBin() error {
 	var err error
 	e.runnerLog("running...")
-	cmd, stdout, stderr, err := e.startCmd(e.config.Build.Bin)
+	cmd, stdout, stderr, err := e.startCmd(e.config.Build.Shell, e.config.Build.Bin)
 	if err != nil {
 		return err
 	}

--- a/runner/util_darwin.go
+++ b/runner/util_darwin.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"fmt"
 	"io"
 	"os/exec"
 	"syscall"
@@ -19,15 +20,17 @@ func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 		}
 		time.Sleep(e.config.Build.KillDelay * time.Millisecond)
 	}
+
 	// https://stackoverflow.com/questions/22470193/why-wont-go-kill-a-child-process-correctly
 	err = syscall.Kill(-pid, syscall.SIGKILL)
+
 	// Wait releases any resources associated with the Process.
 	_, _ = cmd.Process.Wait()
 	return pid, err
 }
 
-func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
-	c := exec.Command("/bin/sh", "-c", cmd)
+func (e *Engine) startCmd(shell string, cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
+	c := exec.Command(fmt.Sprintf("/bin/%s", shell), "-c", cmd)
 	f, err := pty.Start(c)
 	return c, f, f, err
 }

--- a/runner/util_linux.go
+++ b/runner/util_linux.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"fmt"
 	"io"
 	"os/exec"
 	"syscall"
@@ -28,8 +29,8 @@ func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 	return
 }
 
-func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
-	c := exec.Command("/bin/sh", "-c", cmd)
+func (e *Engine) startCmd(shell string, cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
+	c := exec.Command(fmt.Sprintf("/bin/%s", shell), "-c", cmd)
 	f, err := pty.Start(c)
 	return c, f, f, err
 }


### PR DESCRIPTION
## Gives the user, option to use a custom bash shell instead of executing with default "sh" hardcoded. 
Fixes #77 

Now, add
`shell = <shell_name>` in .air.conf file and air builds using the specific shell.
Example,
`shell = bash`
`shell = dash`
`shell = zsh`

`cmd` runs in the respective shell name specified.

Use case:
1. If user has a custom environment variables as a .env file and wants to source it every time before building. If user uses `bash` for development locally, can add `shell = bash` in .air.conf and the command specified as `cmd = ...` will execute as `/bin/bash` and not as `/bin/sh`

My use case: I used `bash` to source a file with command `source dev.env` and `source` doesn't work in `sh`, the alternative didn't work too as explained in #77 