### PR TITLE
Fixed build and SIGINT race condition and massive sleep after SIGINT

### DIFF
--- a/runner/engine.go
+++ b/runner/engine.go
@@ -416,7 +416,12 @@ func (e *Engine) runBin() error {
 			default:
 			}
 		}()
+
 		<-e.binStopCh
+		e.withLock(func() {
+			e.binRunning = false
+		})
+
 		e.mainDebug("trying to kill pid %d, cmd %+v", cmd.Process.Pid, cmd.Args)
 		defer func() {
 			stdout.Close()
@@ -431,9 +436,6 @@ func (e *Engine) runBin() error {
 		} else {
 			e.mainDebug("cmd killed, pid: %d", pid)
 		}
-		e.withLock(func() {
-			e.binRunning = false
-		})
 		cmdBinPath := cmdPath(e.config.rel(e.config.binPath()))
 		if _, err = os.Stat(cmdBinPath); os.IsNotExist(err) {
 			return

--- a/runner/util_darwin.go
+++ b/runner/util_darwin.go
@@ -17,10 +17,12 @@ func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 		if err = syscall.Kill(-pid, syscall.SIGINT); err != nil {
 			return
 		}
-		time.Sleep(e.config.Build.KillDelay * time.Millisecond)
+		time.Sleep(e.config.Build.KillDelay)
 	}
+
 	// https://stackoverflow.com/questions/22470193/why-wont-go-kill-a-child-process-correctly
 	err = syscall.Kill(-pid, syscall.SIGKILL)
+
 	// Wait releases any resources associated with the Process.
 	_, _ = cmd.Process.Wait()
 	return pid, err

--- a/runner/util_linux.go
+++ b/runner/util_linux.go
@@ -17,7 +17,7 @@ func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 		if err = syscall.Kill(-pid, syscall.SIGINT); err != nil {
 			return
 		}
-		time.Sleep(e.config.Build.KillDelay * time.Millisecond)
+		time.Sleep(e.config.Build.KillDelay)
 	}
 
 	// https://stackoverflow.com/questions/22470193/why-wont-go-kill-a-child-process-correctly
@@ -25,7 +25,7 @@ func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 
 	// Wait releases any resources associated with the Process.
 	_, _ = cmd.Process.Wait()
-	return
+	return pid, err
 }
 
 func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {


### PR DESCRIPTION
This PR addresses two issues. The bigger issue is a race condition that I was seeing when `send_interrupt` config is true. 

When Air successful builds and runs the binary the `e.binRunning` is set to `true`. If then the build fails twice before `e.killCmd(...)` completes (takes 30 second due to sleeping after sending SIGINT) the build logics sends two messages (`e.binRunning` is still `true`) to the `binStopCh` channel, the 2nd message resulting in a block in the middle of `e.withLock`, holding the lock until the channel has room. When the attempt to kill the previous running command finishes sleeping, it cannot get the lock to set `e.binRunning` to `false` resulting in a dead lock.

This PR moves the setting of `Engine.binRunning` to `false` before trying to interrupt/kill the running process, avoiding the the race condition.

The 2nd issue is the sleep was being multiplied by `time.Milliseconds` which was resulting in the duration being multiplied by 1M (see the constants at the bottom of the section at https://golang.org/pkg/time/#pkg-constants).

I also adjusted some white space and returns in the `runner/util_linux.go` and `runner/util_darwin.go` to match.