### PR TITLE
Convert backslashes to slashes for easier cross platform usage.

### DIFF
--- a/runner/util.go
+++ b/runner/util.go
@@ -63,7 +63,7 @@ func isHiddenDirectory(path string) bool {
 }
 
 func cleanPath(path string) string {
-	return strings.TrimSuffix(strings.TrimSpace(path), "/")
+	return strings.TrimSuffix(filepath.ToSlash(strings.TrimSpace(path)), "/")
 }
 
 func (e *Engine) isExcludeDir(path string) bool {


### PR DESCRIPTION
While using air on windows I noticed that the tool would start to monitor sub directories that where added to the exclude_dir section of my toml file.

After some investigation it turns out that rewriting paths to something like "parent\\sub" is needed on windows.
This is unfortunate if some team members use Windows while others use Linux or MacOS.

This change allows to keep the forward slash format for matching against excluded/include_dir/file entries independently from the underlying OS.