### PR TITLE
Support Terminal UI Applications, such as written with tview

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,10 @@ require (
 )
 
 require github.com/creack/pty v1.1.11
+require (
+	github.com/pkg/errors v0.9.1
+	golang.org/x/term v0.0.0-20220411215600-e5f449aeb171
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,9 +23,12 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+golang.org/x/term v0.0.0-20220411215600-e5f449aeb171 h1:EH1Deb8WZJ0xc0WK//leUHXcX9aLE5SymusoTmMZye8=
+golang.org/x/term v0.0.0-20220411215600-e5f449aeb171/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/runner/config.go
+++ b/runner/config.go
@@ -50,6 +50,7 @@ type cfgBuild struct {
 	StopOnError      bool          `toml:"stop_on_error"`
 	SendInterrupt    bool          `toml:"send_interrupt"`
 	KillDelay        time.Duration `toml:"kill_delay"`
+	TermUIApp        bool          `toml:"term_ui_app"`
 	regexCompiled    []*regexp.Regexp
 }
 

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/term"
+
 	"github.com/fsnotify/fsnotify"
 )
 
@@ -35,6 +37,8 @@ type Engine struct {
 	fileChecksums *checksumMap
 
 	ll sync.Mutex // lock for logger
+
+	oldStdoutState *term.State
 }
 
 // NewEngineWithConfig ...
@@ -327,6 +331,12 @@ func (e *Engine) start() {
 			time.Sleep(e.config.buildDelay())
 			e.flushEvents()
 
+			// When running a Terminal UI Application, especially when killing it (due to code change)
+			// Need to restore terminal state otherwise text may come out unclear (like ignoring CR in text output)
+			if e.config.Build.TermUIApp {
+				term.Restore(int(os.Stdout.Fd()), e.oldStdoutState)
+			}
+
 			// clean on rebuild https://stackoverflow.com/questions/22891644/how-can-i-clear-the-terminal-screen-in-go
 			if e.config.Screen.ClearOnRebuild {
 				fmt.Println("\033[2J")
@@ -335,7 +345,6 @@ func (e *Engine) start() {
 			e.mainLog("%s has changed", e.config.rel(filename))
 		case <-firstRunCh:
 			// go down
-			break
 		}
 
 		// already build and run now
@@ -426,6 +435,11 @@ func (e *Engine) runBin() error {
 	var err error
 	e.runnerLog("running...")
 
+	// When running Terminal UI Application store terminal state for restoring after killing the app
+	if e.config.Build.TermUIApp {
+		e.oldStdoutState, _ = term.GetState(int(os.Stdout.Fd()))
+	}
+
 	command := strings.Join(append([]string{e.config.Build.Bin}, e.runArgs...), " ")
 	cmd, stdout, stderr, err := e.startCmd(command)
 	if err != nil {
@@ -457,6 +471,11 @@ func (e *Engine) runBin() error {
 		if err != nil {
 			e.mainDebug("failed to kill PID %d, error: %s", pid, err.Error())
 			if cmd.ProcessState != nil && !cmd.ProcessState.Exited() {
+				// Before exising, in case of Terminal UI Application, restoring terminal state
+				if e.config.Build.TermUIApp && e.oldStdoutState != nil {
+					term.Restore(int(os.Stdout.Fd()), e.oldStdoutState)
+				}
+
 				os.Exit(1)
 			}
 		} else {

--- a/runner/util_darwin.go
+++ b/runner/util_darwin.go
@@ -27,9 +27,14 @@ func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 
 func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
 	c := exec.Command("/bin/sh", "-c", cmd)
-	// because using pty cannot have same pgid
-	c.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid: true,
+
+	// When running Terminal UI Applications, not sure why, but when using the setpgid (which runs the process under a new pgid)
+	// the application doesn't show. This change has implications on how process needs to be killed later on
+	if !e.config.Build.TermUIApp {
+		// because using pty cannot have same pgid
+		c.SysProcAttr = &syscall.SysProcAttr{
+			Setpgid: true,
+		}
 	}
 
 	stderr, err := c.StderrPipe()


### PR DESCRIPTION
When trying to use air (As well as other similar projects) for developing a terminal based application (examples for applications call terminal based applications are k9s, lazygit, etc. using for example tview) it didn't work.
So I tried adding support for such applications to air (as described below). This required changes to how the application is launched and then killed and also require some messing with the terminal, which those apps mess with and when killed don't restore.
In order to use this new execution approach and terminal tweaking, I added a configuration to the build section (where the kill configurations are) called "term_ui_app" of type boolean. When true it changes the behavior, otherwise it keeps the standard air behavior.

Some more technical details - 
This change involves two key changes:
1. Different execution and kill - not creating a new pgid and then
   killing only the process
2. Storing terminal state before running the app and restoring it after
   killing the app so texts coming out to terminal will not be affected
   by the terminal state caused by the app (when app doesn't restore it
   on its own when being killed)