### PR TITLE
Handle absolute paths in config

### DIFF
--- a/runner/config.go
+++ b/runner/config.go
@@ -334,7 +334,7 @@ func (c *Config) colorInfo() map[string]string {
 }
 
 func (c *Config) buildLogPath() string {
-	return filepath.Join(c.tmpPath(), c.Build.Log)
+	return joinPath(c.tmpPath(), c.Build.Log)
 }
 
 func (c *Config) buildDelay() time.Duration {
@@ -346,15 +346,15 @@ func (c *Config) rerunDelay() time.Duration {
 }
 
 func (c *Config) binPath() string {
-	return filepath.Join(c.Root, c.Build.Bin)
+	return joinPath(c.Root, c.Build.Bin)
 }
 
 func (c *Config) tmpPath() string {
-	return filepath.Join(c.Root, c.TmpDir)
+	return joinPath(c.Root, c.TmpDir)
 }
 
 func (c *Config) testDataPath() string {
-	return filepath.Join(c.Root, c.TestDataDir)
+	return joinPath(c.Root, c.TestDataDir)
 }
 
 func (c *Config) rel(path string) string {

--- a/runner/util.go
+++ b/runner/util.go
@@ -379,3 +379,11 @@ func setTage2Map(root string, t reflect.Type, m map[string]TomlInfo, fieldPath s
 		}
 	}
 }
+
+func joinPath(root, path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+
+	return filepath.Join(root, path)
+}

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -286,3 +286,33 @@ func TestCheckIncludeFile(t *testing.T) {
 	assert.Equal(t, e.checkIncludeFile("no.go"), false)
 	assert.Equal(t, e.checkIncludeFile("."), false)
 }
+
+func TestJoinPathRelative(t *testing.T) {
+	root, err := filepath.Abs("test")
+
+	if err != nil {
+		t.Fatalf("couldn't get absolute path for testing: %v", err)
+	}
+
+	result := joinPath(root, "x")
+
+	assert.Equal(t, result, filepath.Join(root, "x"))
+}
+
+func TestJoinPathAbsolute(t *testing.T) {
+	root, err := filepath.Abs("test")
+
+	if err != nil {
+		t.Fatalf("couldn't get absolute path for testing: %v", err)
+	}
+
+	path, err := filepath.Abs("x")
+
+	if err != nil {
+		t.Fatalf("couldn't get absolute path for testing: %v", err)
+	}
+
+	result := joinPath(root, path)
+
+	assert.Equal(t, result, path)
+}


### PR DESCRIPTION
Was trying to use `/tmp/air` as `tmp_dir` but it did not work well. `filepath.Join` simply concatenates both components, resulting in something like `/home/user/myproj/tmp/air`, which is counter-intuitive.