### PR TITLE
fix: Kill the old process after a successful rebuild

### DIFF
--- a/runner/engine.go
+++ b/runner/engine.go
@@ -355,11 +355,6 @@ func (e *Engine) start() {
 		default:
 		}
 
-		// if current app is running, stop it
-		e.withLock(func() {
-			close(e.binStopCh)
-			e.binStopCh = make(chan bool)
-		})
 		go e.buildRun()
 	}
 }
@@ -395,6 +390,13 @@ func (e *Engine) buildRun() {
 		return
 	default:
 	}
+
+	// if current app is running, stop it
+	e.withLock(func() {
+		close(e.binStopCh)
+		e.binStopCh = make(chan bool)
+	})
+
 	if err = e.runBin(); err != nil {
 		e.runnerLog("failed to run, error: %s", err.Error())
 	}


### PR DESCRIPTION
kill process after rebuilding should be better. 
fix #399 