### PR TITLE
Checksum of binary file

### DIFF
--- a/air_example.toml
+++ b/air_example.toml
@@ -65,3 +65,9 @@ runner = "green"
 [misc]
 # Delete tmp directory on exit
 clean_on_exit = true
+
+[screen]
+# Clear screen while rebuild
+clear_on_rebuild = false
+# Keep screen scroll while clear
+keep_scroll = true

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -1,8 +1,10 @@
 package runner
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -359,6 +361,15 @@ func (e *Engine) start() {
 			close(e.binStopCh)
 			e.binStopCh = make(chan bool)
 		})
+
+		// checksum with existed bin file and run it
+		if err := e.sumExistAndRun(); err != nil {
+			e.mainDebug("file checksum failed: %s", err.Error())
+		} else {
+			e.checkerLog("find existed bin and running it")
+			continue
+		}
+
 		go e.buildRun()
 	}
 }
@@ -394,6 +405,11 @@ func (e *Engine) buildRun() {
 		return
 	default:
 	}
+
+	if err = e.sumBin(); err != nil {
+		e.mainDebug("failed to get sum, error: %s", err.Error())
+	}
+
 	if err = e.runBin(); err != nil {
 		e.runnerLog("failed to run, error: %s", err.Error())
 	}
@@ -426,6 +442,42 @@ func (e *Engine) building() error {
 	// wait for building
 	err = cmd.Wait()
 	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (e *Engine) sumExistAndRun() error {
+	binName := strings.Split(e.config.Build.Bin, " ")
+	checksum, err := fileChecksum(binName[len(binName)-1])
+	if err != nil {
+		return err
+	}
+	// compare file checksum
+	shaFile := binName[len(binName)-1] + ".sha"
+	shaText, err := os.ReadFile(shaFile)
+	if err != nil {
+		return err
+	}
+	if checksum != string(shaText) {
+		return errors.New("file checksum mismatching")
+	}
+	// run existed bin file
+	if err = e.runBin(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (e *Engine) sumBin() error {
+	binName := strings.Split(e.config.Build.Bin, " ")
+	checksum, err := fileChecksum(binName[len(binName)-1])
+	if err != nil {
+		return err
+	}
+	// save file checksum
+	shaFile := binName[len(binName)-1] + ".sha"
+	if err = os.WriteFile(shaFile, []byte(checksum), fs.ModePerm); err != nil {
 		return err
 	}
 	return nil

--- a/runner/logger.go
+++ b/runner/logger.go
@@ -87,6 +87,10 @@ func (l *logger) build() logFunc {
 	return l.getLogger("build")
 }
 
+func (l *logger) checker() logFunc {
+	return l.getLogger("checker")
+}
+
 func (l *logger) runner() logFunc {
 	return l.getLogger("runner")
 }

--- a/runner/util.go
+++ b/runner/util.go
@@ -40,6 +40,14 @@ func (e *Engine) buildLog(format string, v ...interface{}) {
 	}
 }
 
+func (e *Engine) checkerLog(format string, v ...interface{}) {
+	if e.debugMode || !e.config.Log.MainOnly {
+		e.logWithLock(func() {
+			e.logger.checker()(format, v...)
+		})
+	}
+}
+
 func (e *Engine) runnerLog(format string, v ...interface{}) {
 	if e.debugMode || !e.config.Log.MainOnly {
 		e.logWithLock(func() {


### PR DESCRIPTION
Save the checksum of the binary file after the project is compiled, and check it the next time you start Air to avoid repeated builds (very critical when used in a Docker container, to avoid building a large number of projects at the same time when Docker restarts)