### PR TITLE
Add global default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ air -c .air.toml
 ```
 
 You can initialize the `.air.toml` configuration file to the current directory with the default settings running the following command.
+You can also create a global default for `.air.toml` in `~/.air.toml`. 
 
 ```bash
 air init

--- a/runner/config.go
+++ b/runner/config.go
@@ -18,6 +18,7 @@ import (
 const (
 	dftTOML = ".air.toml"
 	dftConf = ".air.conf"
+	dftGlobTOML= "~/.air.toml"
 	airWd   = "air_wd"
 )
 
@@ -207,7 +208,18 @@ func readConfByName(name string) (*Config, error) {
 	return cfg, err
 }
 
+func defaultGlobalConfig() (*Config, error) {
+	defaultConfigPath, _ := expandPath(dftGlobTOML)
+	cfg, err := readConfig(defaultConfigPath)
+	return cfg, err
+}
+
 func defaultConfig() Config {
+	cfg, err := defaultGlobalConfig()
+	if err == nil {
+		return *cfg
+	}
+
 	build := cfgBuild{
 		Cmd:          "go build -o ./tmp/main .",
 		Bin:          "./tmp/main",


### PR DESCRIPTION
Added the ability to specify your own default config.
Think it's a nice convenience, in my case, I wanted to change the tmp directory to a hidden directory for example
and it's a bit annoying to have to update the air.toml in each project.