### PR TITLE
Adding Extra Logs for Config Reading Behaviour

### DIFF
--- a/runner/config.go
+++ b/runner/config.go
@@ -176,15 +176,18 @@ func writeDefaultConfig() (string, error) {
 
 func defaultPathConfig() (*Config, error) {
 	// when path is blank, first find `.air.toml`, `.air.conf` in `air_wd` and current working directory, if not found, use defaults
-	for _, name := range []string{dftTOML, dftConf} {
-		cfg, err := readConfByName(name)
-		if err == nil {
-			if name == dftConf {
-				fmt.Println("`.air.conf` will be deprecated soon, recommend using `.air.toml`.")
-			}
-			return cfg, nil
-		}
+	cfg, err := readConfByName(dftTOML)
+	if err == nil {
+		return cfg, nil
 	}
+	fmt.Printf("could not read .air.toml {%v}, trying .air.conf\n", err)
+
+	cfg, err = readConfByName(dftConf)
+	if err == nil {
+		fmt.Println("`.air.conf` will be deprecated soon, recommend using `.air.toml`.")
+		return cfg, nil
+	}
+	fmt.Printf("could not read .air.conf {%v}, using default config\n", err)
 
 	dftCfg := defaultConfig()
 	return &dftCfg, nil


### PR DESCRIPTION
Improves the logs for #516 . After looking into the codebase, I understand that the following behaviour is intended:

1. read `.air.toml` if available.
2. failing above, read `.air.conf` if available.
3. failing above, use default configs.

The issue is that the user currently has no idea if they simply run `air` from their repo, with an invalid `.air.toml`. It is 100% clearer to log the behaviour so the user doesn't waste time (like I did) wondering why my `.air.toml` settings weren't picked up !