### PR TITLE
Redirect to browser after build

### DIFF
--- a/air_example.toml
+++ b/air_example.toml
@@ -54,6 +54,8 @@ rerun_delay = 500
 args_bin = ["hello", "world"]
 # Open URL in browser when the build is finished
 app_url = "http://localhost:8080"
+# Delay after build before open URL
+app_url_open_delay = 500
 
 [log]
 # Show log time

--- a/air_example.toml
+++ b/air_example.toml
@@ -52,6 +52,8 @@ rerun = false
 rerun_delay = 500
 # Add additional arguments when running binary (bin/full_bin). Will run './tmp/main hello world'.
 args_bin = ["hello", "world"]
+# Open URL in browser when the build is finished
+app_url = "http://localhost:8080"
 
 [log]
 # Show log time

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
+	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/afero v1.9.3 // indirect
 	github.com/tdewolff/parse/v2 v2.6.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,8 @@ github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3v
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
 github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
+github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
+github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -324,6 +326,7 @@ golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/runner/config.go
+++ b/runner/config.go
@@ -58,6 +58,7 @@ type cfgBuild struct {
 	Rerun            bool          `toml:"rerun"`
 	RerunDelay       int           `toml:"rerun_delay"`
 	AppUrl           string        `toml:"app_url"`
+	AppUrlOpenDelay  int           `toml:"app_url_open_delay"`
 	regexCompiled    []*regexp.Regexp
 }
 

--- a/runner/config.go
+++ b/runner/config.go
@@ -57,6 +57,7 @@ type cfgBuild struct {
 	KillDelay        time.Duration `toml:"kill_delay"`
 	Rerun            bool          `toml:"rerun"`
 	RerunDelay       int           `toml:"rerun_delay"`
+	AppUrl           string        `toml:"app_url"`
 	regexCompiled    []*regexp.Regexp
 }
 

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -2,12 +2,12 @@ package runner
 
 import (
 	"fmt"
+	"github.com/pkg/browser"
 	"io"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -420,21 +420,7 @@ func (e *Engine) buildRun() {
 }
 
 func (e *Engine) openBrowser() error {
-	var err error
-
-	url := e.config.Build.AppUrl
-	switch runtime.GOOS {
-	case "windows":
-		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
-	case "darwin":
-		err = exec.Command("open", url).Start()
-	case "linux":
-		err = exec.Command("xdg-open", url).Start()
-	default:
-		err = exec.Command("open", url).Start()
-	}
-
-	return err
+	return browser.OpenURL(e.config.Build.AppUrl)
 }
 
 func (e *Engine) flushEvents() {

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -409,10 +409,13 @@ func (e *Engine) buildRun() {
 	}
 
 	if e.config.Build.AppUrl != "" {
-		e.runnerLog("opening browser: %s", e.config.Build.AppUrl)
-		if err = e.openBrowser(); err != nil {
-			e.runnerLog("failed to open browser: %s", err.Error())
-		}
+		go func() {
+			time.Sleep(time.Duration(e.config.Build.AppUrlOpenDelay) * time.Millisecond)
+			e.runnerLog("opening browser: %s", e.config.Build.AppUrl)
+			if err = e.openBrowser(); err != nil {
+				e.runnerLog("failed to open browser: %s", err.Error())
+			}
+		}()
 	}
 }
 


### PR DESCRIPTION
`AppUrl` is used to open browser URL when the build is finished. `AppUrlOpenDelay` waits when server is ready to accept requests.