### PR TITLE
Fix color output on Windows

### DIFF
--- a/runner/util_windows.go
+++ b/runner/util_windows.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"io"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -29,6 +30,10 @@ func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, 
 	if err != nil {
 		return nil, nil, nil, err
 	}
+
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+
 	err = c.Start()
 	if err != nil {
 		return nil, nil, nil, err


### PR DESCRIPTION
Fix #128 

I simply compare `util_windows.go` with `util_unix.go`, and setting `c.Stdout`, `c.Stderr` seems to have resolve this issue.

## Screenshot

![image](https://github.com/cosmtrek/air/assets/105704427/386b0dc3-0cf3-4d16-b8ce-32ee02a9408f)
