### PR TITLE
Fix go directive to avoid language version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmtrek/air
 
-go 1.22
+go 1.22.0
 
 require (
 	dario.cat/mergo v1.0.0


### PR DESCRIPTION
Specifying 1.22 (referred to as the language version) without the toolchain directive causes compilation to fail when developers uses older go like 1.21.
To workaround, I recommend to specify `go 1.22.0`.

https://github.com/golang/go/issues/62278#issuecomment-2015737150