### PR TITLE
fix the stop_on_error is false configuration does not work

### DIFF
--- a/runner/engine.go
+++ b/runner/engine.go
@@ -502,12 +502,14 @@ func (e *Engine) runBin() error {
 		} else {
 			e.mainDebug("cmd killed, pid: %d", pid)
 		}
-		cmdBinPath := cmdPath(e.config.rel(e.config.binPath()))
-		if _, err = os.Stat(cmdBinPath); os.IsNotExist(err) {
-			return
-		}
-		if err = os.Remove(cmdBinPath); err != nil {
-			e.mainLog("failed to remove %s, error: %s", e.config.rel(e.config.binPath()), err)
+		if e.config.Build.StopOnError {
+			cmdBinPath := cmdPath(e.config.rel(e.config.binPath()))
+			if _, err = os.Stat(cmdBinPath); os.IsNotExist(err) {
+				return
+			}
+			if err = os.Remove(cmdBinPath); err != nil {
+				e.mainLog("failed to remove %s, error: %s", e.config.rel(e.config.binPath()), err)
+			}
 		}
 	}
 


### PR DESCRIPTION
当我配置stop_on_error=false的时候，如果coding编译失败，就不应该删除之前构建成功的执行文件