### PR TITLE
fix: escape spaces in bin

### DIFF
--- a/runner/config.go
+++ b/runner/config.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
+	"strings"
 	"time"
 
 	"dario.cat/mergo"
@@ -320,6 +321,9 @@ func (c *Config) preprocess() error {
 	// Fix windows CMD processor
 	// CMD will not recognize relative path like ./tmp/server
 	c.Build.Bin, err = filepath.Abs(c.Build.Bin)
+
+	// escape spaces
+	c.Build.Bin = strings.Replace(c.Build.Bin, " ", "\\ ", -1)
 
 	return err
 }

--- a/runner/config_test.go
+++ b/runner/config_test.go
@@ -69,6 +69,25 @@ func TestBinCmdPath(t *testing.T) {
 	}
 }
 
+func TestBinPathSpaceEscape(t *testing.T) {
+	c := &Config{
+		Build: cfgBuild{
+			Bin: "./with spaces/main",
+		},
+	}
+
+	err := c.preprocess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(c.Build.Bin, "with spaces") {
+		t.Fatalf("should escape spaces in bin path")
+	}
+	if !strings.Contains(c.Build.Bin, "with\\ spaces") {
+		t.Fatalf("should escape spaces in bin path")
+	}
+}
+
 func TestDefaultPathConfig(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Air was unable to run my binary because there were spaces in the path, the same issue is described here -> #546.

This change fixes it by escaping spaces in the path at config setup time.


