### PR TITLE
hold cleanup until signal on `procKilledCh`

### DIFF
--- a/runner/engine.go
+++ b/runner/engine.go
@@ -567,6 +567,8 @@ func (e *Engine) runBin() error {
 					e.runnerLog("Process Exit with Code: %v", state.ExitCode())
 				}
 
+				e.procKilledCh <- true
+
 				if !e.config.Build.Rerun {
 					return
 				}

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -567,8 +567,6 @@ func (e *Engine) runBin() error {
 					e.runnerLog("Process Exit with Code: %v", state.ExitCode())
 				}
 
-				e.procKilledCh <- true
-
 				if !e.config.Build.Rerun {
 					return
 				}

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -492,6 +492,7 @@ func (e *Engine) runBin() error {
 
 		e.mainDebug("trying to kill pid %d, cmd %+v", cmd.Process.Pid, cmd.Args)
 		defer func() {
+			e.procKilledCh <- true
 			stdout.Close()
 			stderr.Close()
 		}()
@@ -506,13 +507,11 @@ func (e *Engine) runBin() error {
 		}
 		cmdBinPath := cmdPath(e.config.rel(e.config.binPath()))
 		if _, err = os.Stat(cmdBinPath); os.IsNotExist(err) {
-			e.procKilledCh <- true
 			return
 		}
 		if err = os.Remove(cmdBinPath); err != nil {
 			e.mainLog("failed to remove %s, error: %s", e.config.rel(e.config.binPath()), err)
 		}
-		e.procKilledCh <- true
 	}
 
 	e.runnerLog("running...")


### PR DESCRIPTION
Fixes #534 on my 2021 M1 Pro MBP - Sonoma 14.4.1

#542 got it to a solid starting point so this was pretty simple? Thanks to whatever @ghost wrote that.

Hopefully this fixes for everyone on a Mac? 🤞🏻

---

There's still a downside: When you reach a non zero exit code, you are trapped and have to kill the pid via external means. It does at least let you ctrl+c under normal circumstances.