### PR TITLE
fix: `--build.bin` path for windows

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,7 +95,13 @@ func main() {
 		log.Fatal(err)
 		return
 	}
-	cfg.WithArgs(cmdArgs)
+
+	err = cfg.WithArgs(cmdArgs)
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
+
 	r, err := runner.NewEngineWithConfig(cfg, debugMode)
 	if err != nil {
 		log.Fatal(err)

--- a/runner/config.go
+++ b/runner/config.go
@@ -383,16 +383,20 @@ func (c *Config) rel(path string) string {
 }
 
 // WithArgs returns a new config with the given arguments added to the configuration.
-func (c *Config) WithArgs(args map[string]TomlInfo) {
+func (c *Config) WithArgs(args map[string]TomlInfo) error {
 	for key, value := range args {
 		if value.Value != nil && *value.Value != unsetDefault {
 			// To avoid path resolving problems on Windows.
 			if key == "build.bin" {
-				abs, _ := filepath.Abs(*value.Value)
+				abs, err := filepath.Abs(*value.Value)
+				if err != nil {
+					return err
+				}
 				value.Value = &abs
 			}
 			v := reflect.ValueOf(c)
 			setValue2Struct(v, value.fieldPath, *value.Value)
 		}
 	}
+	return nil
 }

--- a/runner/config.go
+++ b/runner/config.go
@@ -384,8 +384,13 @@ func (c *Config) rel(path string) string {
 
 // WithArgs returns a new config with the given arguments added to the configuration.
 func (c *Config) WithArgs(args map[string]TomlInfo) {
-	for _, value := range args {
+	for key, value := range args {
 		if value.Value != nil && *value.Value != unsetDefault {
+			// To avoid path resolving problems on Windows.
+			if key == "build.bin" {
+				abs, _ := filepath.Abs(*value.Value)
+				value.Value = &abs
+			}
 			v := reflect.ValueOf(c)
 			setValue2Struct(v, value.fieldPath, *value.Value)
 		}

--- a/runner/config_test.go
+++ b/runner/config_test.go
@@ -203,6 +203,29 @@ func TestKillDelay(t *testing.T) {
 	}
 }
 
+func TestWithArgs(t *testing.T) {
+	testData := []struct {
+		bin string
+	}{{
+		bin: "bin\\main.exe",
+	}, {bin: "bin/main.exe"}}
+
+	for _, test := range testData {
+		config := Config{}
+		args := map[string]TomlInfo{
+			"build.bin": {
+				Value: &test.bin,
+			},
+		}
+		err := config.WithArgs(args)
+
+		if err != nil {
+			t.Fatal("Test shouldn't have failed, found: ", err)
+		}
+	}
+
+}
+
 func contains(sl []string, target string) bool {
 	for _, c := range sl {
 		if c == target {

--- a/runner/flag.go
+++ b/runner/flag.go
@@ -6,7 +6,8 @@ import (
 
 const unsetDefault = "DEFAULT"
 
-// ParseConfigFlag parse toml information for flag
+// ParseConfigFlag parse toml information for flag and register
+// keys as Vars in `flag` to be filled later when using `.Parse()`
 func ParseConfigFlag(f *flag.FlagSet) map[string]TomlInfo {
 	c := Config{}
 	m := flatConfig(c)


### PR DESCRIPTION
closes #589 
## Changes
- Path fed to `--build.bin` is converted to an absolute path always as it is done [here](https://github.com/cosmtrek/air/blob/f6733207ad2d6e5e682448a72c67c7af37c6d7ed/runner/config.go#L329)
### Any breaking change
No
### Is this change easily revertible 
Yes