### PR TITLE
add support for environment files

### DIFF
--- a/runner/config.go
+++ b/runner/config.go
@@ -58,6 +58,7 @@ type cfgBuild struct {
 	KillDelay        time.Duration `toml:"kill_delay"`
 	Rerun            bool          `toml:"rerun"`
 	RerunDelay       int           `toml:"rerun_delay"`
+	EnvironmentFile  string        `toml:"environment_file"`
 	regexCompiled    []*regexp.Regexp
 }
 

--- a/runner/environment.go
+++ b/runner/environment.go
@@ -1,0 +1,30 @@
+package runner
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func (e *Engine) modifyEnvironment(c *exec.Cmd) error {
+	if e.config.Build.EnvironmentFile == "" {
+		return nil
+	}
+
+	env := os.Environ()
+
+	envFile, err := os.Open(e.config.Build.EnvironmentFile)
+	if err != nil {
+		return fmt.Errorf("failed to open environment file: %w")
+	}
+	defer envFile.Close()
+
+	scan := bufio.NewScanner(envFile)
+	for scan.Scan() {
+		env = append(env, scan.Text())
+	}
+
+	c.Env = env
+	return nil
+}

--- a/runner/util_linux.go
+++ b/runner/util_linux.go
@@ -30,6 +30,10 @@ func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 
 func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
 	c := exec.Command("/bin/sh", "-c", cmd)
+	err := e.modifyEnvironment(c)
+	if err != nil {
+		return nil, nil, nil, err
+	}
 	f, err := pty.Start(c)
 	return c, f, f, err
 }

--- a/runner/util_unix.go
+++ b/runner/util_unix.go
@@ -33,6 +33,10 @@ func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, 
 	c.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid: true,
 	}
+	err := e.modifyEnvironment(c)
+	if err != nil {
+		return nil, nil, nil, err
+	}
 
 	stderr, err := c.StderrPipe()
 	if err != nil {

--- a/runner/util_windows.go
+++ b/runner/util_windows.go
@@ -25,6 +25,10 @@ func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, 
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	err = e.modifyEnvironment(c)
+	if err != nil {
+		return nil, nil, nil, err
+	}
 	stdout, err := c.StdoutPipe()
 	if err != nil {
 		return nil, nil, nil, err


### PR DESCRIPTION
At times, it is necessary or at least easier to set environment variables using a file.

Add a function that augments the environment of the spawned process with the provided variables.

Tested to work on Linux. Not sure on how to write a test for it without either passing in the content as a reader or basically testing stdlib IO functions.