### PR TITLE
Use web page address when making request to reload proxy

### DIFF
--- a/runner/proxy.go
+++ b/runner/proxy.go
@@ -68,7 +68,7 @@ func (p *Proxy) injectLiveReload(resp *http.Response) (string, error) {
 		return page, nil
 	}
 
-	script := `<script>new EventSource(window.location.protocol + "//" + window.location.host + "/internal/reload").onmessage = () => { location.reload() }</script>`
+	script := `<script>new EventSource("/internal/reload").onmessage = () => { location.reload() }</script>`
 	return page[:body] + script + page[body:], nil
 }
 

--- a/runner/proxy.go
+++ b/runner/proxy.go
@@ -68,10 +68,7 @@ func (p *Proxy) injectLiveReload(resp *http.Response) (string, error) {
 		return page, nil
 	}
 
-	script := fmt.Sprintf(
-		`<script>new EventSource("http://localhost:%d/internal/reload").onmessage = () => { location.reload() }</script>`,
-		p.config.ProxyPort,
-	)
+	script := `<script>new EventSource(window.location.protocol + "//" + window.location.host + "/internal/reload").onmessage = () => { location.reload() }</script>`
 	return page[:body] + script + page[body:], nil
 }
 

--- a/runner/proxy_test.go
+++ b/runner/proxy_test.go
@@ -190,7 +190,7 @@ func TestProxy_injectLiveReload(t *testing.T) {
 				},
 				Body: io.NopCloser(strings.NewReader(`<body><h1>test</h1></body>`)),
 			},
-			expect: `<body><h1>test</h1><script>new EventSource("http://localhost:1111/internal/reload").onmessage = () => { location.reload() }</script></body>`,
+			expect: `<body><h1>test</h1><script>new EventSource(window.location.protocol + "//" + window.location.host + "/internal/reload").onmessage = () => { location.reload() }</script></body>`,
 		},
 	}
 	for _, tt := range tests {

--- a/runner/proxy_test.go
+++ b/runner/proxy_test.go
@@ -190,7 +190,7 @@ func TestProxy_injectLiveReload(t *testing.T) {
 				},
 				Body: io.NopCloser(strings.NewReader(`<body><h1>test</h1></body>`)),
 			},
-			expect: `<body><h1>test</h1><script>new EventSource(window.location.protocol + "//" + window.location.host + "/internal/reload").onmessage = () => { location.reload() }</script></body>`,
+			expect: `<body><h1>test</h1><script>new EventSource("/internal/reload").onmessage = () => { location.reload() }</script></body>`,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Hello. I often use tailscale to share development process of web pages with my team. Using tailscale you can create a tunnel from your local machine with a public address such as `machine.id.ts.net` but air always connects to `localhost` so live reload can't work on my teammates browsers.

This pr makes browser reload script connect to web page's host.

It works with `localhost:port` and with regular addresses. It works with both `http` and `https`.
I've ran it on linux firefox, chrome and on macOS safari. Seems to be working all right.