### PR TITLE
fix README_zh_cn go install command

### DIFF
--- a/README-zh_cn.md
+++ b/README-zh_cn.md
@@ -45,7 +45,7 @@ air --build.cmd "go build -o bin/api cmd/run.go" --build.bin "./bin/api" --build
 使用 go 1.22 或更高版本:
 
 ```shell
-go install github.com/cosmtrek/air@latest
+go install github.com/air-verse/air@latest
 ```
 
 ### 使用 install.sh


### PR DESCRIPTION
the command from https://github.com/air-verse/air/pull/601/files#diff-69b5e601b7e609160e2aaf43356b857c2c623a1269120d921b923e363e018c88R48 not work.
```bash
> go install github.com/cosmtrek/air@latest
go: downloading github.com/cosmtrek/air v1.52.3
go: github.com/cosmtrek/air@latest: version constraints conflict:
        github.com/cosmtrek/air@v1.52.3: parsing go.mod:
        module declares its path as: github.com/air-verse/air
                but was required as: github.com/cosmtrek/air
```
Should be fixed