### PR TITLE
feat: silent flag in .air.toml, suppressing all air prints

### DIFF
--- a/air_example.toml
+++ b/air_example.toml
@@ -58,6 +58,8 @@ rerun_delay = 500
 time = false
 # Only show main log (silences watcher, build, runner)
 main_only = false
+# silence all logs produced by air 
+silent = false
 
 [color]
 # Customize each part's color. If no color found, use the raw app log.

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func GetVersionInfo() versionInfo { //revive:disable:unexported-return
 	}
 }
 
-func main() {
+func printSplash() {
 	versionInfo := GetVersionInfo()
 	fmt.Printf(`
   __    _   ___  
@@ -78,13 +78,12 @@ func main() {
 /_/--\ |_| |_| \_ %s, built with Go %s
 
 `, versionInfo.airVersion, versionInfo.goVersion)
+}
 
+func main() {
 	if showVersion {
+		printSplash()
 		return
-	}
-
-	if debugMode {
-		fmt.Println("[debug] mode")
 	}
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
@@ -96,6 +95,12 @@ func main() {
 		return
 	}
 	cfg.WithArgs(cmdArgs)
+	if !cfg.Log.Silent {
+		printSplash()
+	}
+	if debugMode && !cfg.Log.Silent {
+		fmt.Println("[debug] mode")
+	}
 	r, err := runner.NewEngineWithConfig(cfg, debugMode)
 	if err != nil {
 		log.Fatal(err)

--- a/runner/config.go
+++ b/runner/config.go
@@ -78,6 +78,7 @@ func (c *cfgBuild) RegexCompiled() ([]*regexp.Regexp, error) {
 type cfgLog struct {
 	AddTime  bool `toml:"time"`
 	MainOnly bool `toml:"main_only"`
+	Silent   bool `toml:"silent"`
 }
 
 type cfgColor struct {
@@ -186,7 +187,7 @@ func defaultPathConfig() (*Config, error) {
 	for _, name := range []string{dftTOML, dftConf} {
 		cfg, err := readConfByName(name)
 		if err == nil {
-			if name == dftConf {
+			if name == dftConf && !cfg.Log.Silent {
 				fmt.Println("`.air.conf` will be deprecated soon, recommend using `.air.toml`.")
 			}
 			return cfg, nil
@@ -237,6 +238,7 @@ func defaultConfig() Config {
 	log := cfgLog{
 		AddTime:  false,
 		MainOnly: false,
+		Silent:   false,
 	}
 	color := cfgColor{
 		Main:    "magenta",
@@ -304,9 +306,6 @@ func (c *Config) preprocess() error {
 	}
 	if c.TestDataDir == "" {
 		c.TestDataDir = "testdata"
-	}
-	if err != nil {
-		return err
 	}
 	ed := c.Build.ExcludeDir
 	for i := range ed {

--- a/runner/logger.go
+++ b/runner/logger.go
@@ -53,6 +53,9 @@ func newLogFunc(colorname string, cfg cfgLog) logFunc {
 	return func(msg string, v ...interface{}) {
 		// There are some escape sequences to format color in terminal, so cannot
 		// just trim new line from right.
+		if cfg.Silent {
+			return
+		}
 		msg = strings.ReplaceAll(msg, "\n", "")
 		msg = strings.TrimSpace(msg)
 		if len(msg) == 0 {

--- a/runner/util.go
+++ b/runner/util.go
@@ -21,18 +21,27 @@ const (
 )
 
 func (e *Engine) mainLog(format string, v ...interface{}) {
+	if e.config.Log.Silent {
+		return
+	}
 	e.logWithLock(func() {
 		e.logger.main()(format, v...)
 	})
 }
 
 func (e *Engine) mainDebug(format string, v ...interface{}) {
+	if e.config.Log.Silent {
+		return
+	}
 	if e.debugMode {
 		e.mainLog(format, v...)
 	}
 }
 
 func (e *Engine) buildLog(format string, v ...interface{}) {
+	if e.config.Log.Silent {
+		return
+	}
 	if e.debugMode || !e.config.Log.MainOnly {
 		e.logWithLock(func() {
 			e.logger.build()(format, v...)
@@ -41,6 +50,9 @@ func (e *Engine) buildLog(format string, v ...interface{}) {
 }
 
 func (e *Engine) runnerLog(format string, v ...interface{}) {
+	if e.config.Log.Silent {
+		return
+	}
 	if e.debugMode || !e.config.Log.MainOnly {
 		e.logWithLock(func() {
 			e.logger.runner()(format, v...)
@@ -49,6 +61,9 @@ func (e *Engine) runnerLog(format string, v ...interface{}) {
 }
 
 func (e *Engine) watcherLog(format string, v ...interface{}) {
+	if e.config.Log.Silent {
+		return
+	}
 	if e.debugMode || !e.config.Log.MainOnly {
 		e.logWithLock(func() {
 			e.logger.watcher()(format, v...)
@@ -57,6 +72,9 @@ func (e *Engine) watcherLog(format string, v ...interface{}) {
 }
 
 func (e *Engine) watcherDebug(format string, v ...interface{}) {
+	if e.config.Log.Silent {
+		return
+	}
 	if e.debugMode {
 		e.watcherLog(format, v...)
 	}


### PR DESCRIPTION
useful if the app being watched has structured outputs that are being piped into subsequent program/s.
