### PR TITLE
Bump go to 1.23

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,11 +19,11 @@ jobs:
         id: go
         uses: actions/setup-go@v4
         with:
-          go-version: ^1.22
+          go-version: ^1.23
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59
+          version: v1.60.3
       - name: Install dependency
         run: if [ $(uname) == "Darwin" ]; then brew install gnu-sed ;fi
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ^1.22
+          go-version: ^1.23
 
       - name: Set GOVERSION
         run: echo "GOVERSION=$(go version | sed -r 's/go version go(.*)\ .*/\1/')" >> $GITHUB_ENV

--- a/.github/workflows/smoke_test_reuse_job.yml
+++ b/.github/workflows/smoke_test_reuse_job.yml
@@ -18,7 +18,7 @@ jobs:
         id: go
         uses: actions/setup-go@v4
         with:
-          go-version: ^1.22
+          go-version: ^1.23
       - name: Install
         run: make install
       - name: Check rebuild

--- a/.github/workflows/smoke_test_reuse_job_windows.yml
+++ b/.github/workflows/smoke_test_reuse_job_windows.yml
@@ -18,7 +18,7 @@ jobs:
         id: go
         uses: actions/setup-go@v4
         with:
-          go-version: ^1.22
+          go-version: ^1.23
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 
 LABEL maintainer="Rick Yu <cosmtrek@gmail.com>"
 
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/go/pkg/mod go mod download
 
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build make ci && make install
 
-FROM golang:1.22
+FROM golang:1.23
 
 COPY --from=builder /go/bin/air  /go/bin/air
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LDFLAGS += -X "main.airVersion=$(AIRVER)"
 LDFLAGS += -X "main.goVersion=$(shell go version | sed -r 's/go version go(.*)\ .*/\1/')"
 
 GO := GO111MODULE=on CGO_ENABLED=0 go
-GOLANGCI_LINT_VERSION = v1.56.2
+GOLANGCI_LINT_VERSION = v1.60.3
 
 .PHONY: init
 init: install-golangci-lint

--- a/README-zh_cn.md
+++ b/README-zh_cn.md
@@ -205,7 +205,7 @@ services:
 
 ```Dockerfile
 # 选择你想要的版本，>= 1.16
-FROM golang:1.22-alpine
+FROM golang:1.23-alpine
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ services:
 
 ```Dockerfile
 # Choose whatever you want, version >= 1.16
-FROM golang:1.22-alpine
+FROM golang:1.23-alpine
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/air-verse/air
 
-go 1.22
+go 1.23
 
 require (
 	dario.cat/mergo v1.0.0

--- a/smoke_test/check_rebuild/go.mod
+++ b/smoke_test/check_rebuild/go.mod
@@ -1,3 +1,3 @@
 module air.sample.com
 
-go 1.17
+go 1.23


### PR DESCRIPTION
Bump go version to 1.23 and also golangci-lint to 1.60.3 for compatibility reasons.
Fixes https://github.com/air-verse/air/issues/647