### PR TITLE
wait for killfunc completion when shutting down current app

### DIFF
--- a/runner/engine.go
+++ b/runner/engine.go
@@ -600,6 +600,9 @@ func (e *Engine) runBin() error {
 }
 
 func (e *Engine) stopBin() {
+	e.mainDebug("initiating shutdown sequence")
+	start := time.Now()
+	e.mainDebug("shutdown completed in %v", time.Since(start))
 
 	exitCode := make(chan int)
 	wasRunning := false

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gohugoio/hugo/watcher/filenotify"
@@ -22,16 +23,15 @@ type Engine struct {
 	watcher   filenotify.FileWatcher
 	debugMode bool
 	runArgs   []string
-	running   bool
+	running   atomic.Bool
 
 	eventCh        chan string
 	watcherStopCh  chan bool
 	buildRunCh     chan bool
 	buildRunStopCh chan bool
-	binStopCh      chan bool
+	binStopCh      chan<- chan int
 	exitCh         chan bool
 
-	procKillWg    sync.WaitGroup
 	mu            sync.RWMutex
 	watchers      uint
 	fileChecksums *checksumMap
@@ -57,7 +57,6 @@ func NewEngineWithConfig(cfg *Config, debugMode bool) (*Engine, error) {
 		watcherStopCh:  make(chan bool, 10),
 		buildRunCh:     make(chan bool, 1),
 		buildRunStopCh: make(chan bool, 1),
-		binStopCh:      make(chan bool),
 		exitCh:         make(chan bool),
 		fileChecksums:  &checksumMap{m: make(map[string]string)},
 		watchers:       0,
@@ -316,7 +315,7 @@ func (e *Engine) start() {
 		e.mainLog("Proxy server listening on http://localhost%s", e.proxy.server.Addr)
 	}
 
-	e.running = true
+	e.running.Store(true)
 	firstRunCh := make(chan bool, 1)
 	firstRunCh <- true
 
@@ -366,10 +365,8 @@ func (e *Engine) start() {
 		}
 
 		// if current app is running, stop it
-		e.withLock(func() {
-			close(e.binStopCh)
-			e.binStopCh = make(chan bool)
-		})
+		e.stopBin()
+
 		go e.buildRun()
 	}
 }
@@ -479,43 +476,64 @@ func (e *Engine) runPostCmd() error {
 }
 
 func (e *Engine) runBin() error {
-	killFunc := func(cmd *exec.Cmd, stdout io.ReadCloser, stderr io.ReadCloser, killCh chan struct{}, processExit chan struct{}) {
-		select {
-		// listen to binStopCh
-		// cleanup() will close binStopCh when engine stop
-		// start() will close binStopCh when file changed
-		case <-e.binStopCh:
-			close(killCh)
-			break
+	// killFunc returns a chan of chan of int that should be used to shutdown the bin currently being run
+	// The chan int that is passed in will be used to signal completion of the shutdown
+	killFunc := func(cmd *exec.Cmd, stdout io.ReadCloser, stderr io.ReadCloser, killCh chan<- struct{}, processExit <-chan struct{}) chan<- chan int {
+		shutdown := make(chan chan int)
+		var closer chan int
 
-		// the process is exited, return
-		case <-processExit:
-			return
-		}
+		go func() {
+			defer func() {
+				stdout.Close()
+				stderr.Close()
+			}()
 
-		e.mainDebug("trying to kill pid %d, cmd %+v", cmd.Process.Pid, cmd.Args)
-		defer func() {
-			stdout.Close()
-			stderr.Close()
-		}()
-		pid, err := e.killCmd(cmd)
-		if err != nil {
-			e.mainDebug("failed to kill PID %d, error: %s", pid, err.Error())
-			if cmd.ProcessState != nil && !cmd.ProcessState.Exited() {
-				os.Exit(1)
-			}
-		} else {
-			e.mainDebug("cmd killed, pid: %d", pid)
-		}
-		if e.config.Build.StopOnError {
-			cmdBinPath := cmdPath(e.config.rel(e.config.binPath()))
-			if _, err = os.Stat(cmdBinPath); os.IsNotExist(err) {
+			select {
+			case closer = <-shutdown:
+				// stopBin has been called from start or cleanup
+				// defer the signalling of shutdown completion before attempting to kill further down
+				defer close(closer)
+				defer close(killCh)
+			case <-processExit:
+				// the process is exited, return
+				e.withLock(func() {
+					// Avoid deadlocking any racing shutdown request
+					select {
+					case c := <-shutdown:
+						close(c)
+					default:
+					}
+					e.binStopCh = nil
+				})
 				return
 			}
-			if err = os.Remove(cmdBinPath); err != nil {
-				e.mainLog("failed to remove %s, error: %s", e.config.rel(e.config.binPath()), err)
+
+			e.mainDebug("trying to kill pid %d, cmd %+v", cmd.Process.Pid, cmd.Args)
+
+			pid, err := e.killCmd(cmd)
+			if err != nil {
+				e.mainDebug("failed to kill PID %d, error: %s", pid, err.Error())
+				if cmd.ProcessState != nil && !cmd.ProcessState.Exited() {
+					// Pass a non zero exit code to the closer to delegate the
+					// decision wether to os.Exit or not
+					closer <- 1
+				}
+			} else {
+				e.mainDebug("cmd killed, pid: %d", pid)
 			}
-		}
+
+			if e.config.Build.StopOnError {
+				cmdBinPath := cmdPath(e.config.rel(e.config.binPath()))
+				if _, err = os.Stat(cmdBinPath); os.IsNotExist(err) {
+					return
+				}
+				if err = os.Remove(cmdBinPath); err != nil {
+					e.mainLog("failed to remove %s, error: %s", e.config.rel(e.config.binPath()), err)
+				}
+			}
+		}()
+
+		return shutdown
 	}
 
 	e.runnerLog("running...")
@@ -536,7 +554,6 @@ func (e *Engine) runBin() error {
 			case <-killCh:
 				return
 			default:
-				e.procKillWg.Add(1)
 				command := strings.Join(append([]string{e.config.Build.Bin}, e.runArgs...), " ")
 				cmd, stdout, stderr, _ := e.startCmd(command)
 				processExit := make(chan struct{})
@@ -545,10 +562,9 @@ func (e *Engine) runBin() error {
 					e.proxy.Reload()
 				}
 
+				e.stopBin()
 				e.withLock(func() {
-					close(e.binStopCh)
-					e.binStopCh = make(chan bool)
-					go killFunc(cmd, stdout, stderr, killCh, processExit)
+					e.binStopCh = killFunc(cmd, stdout, stderr, killCh, processExit)
 				})
 
 				go func() {
@@ -562,6 +578,7 @@ func (e *Engine) runBin() error {
 				}()
 				state, _ := cmd.Process.Wait()
 				close(processExit)
+
 				switch state.ExitCode() {
 				case 0:
 					e.runnerLog("Process Exit with Code 0")
@@ -570,7 +587,6 @@ func (e *Engine) runBin() error {
 				default:
 					e.runnerLog("Process Exit with Code: %v", state.ExitCode())
 				}
-				e.procKillWg.Done()
 
 				if !e.config.Build.Rerun {
 					return
@@ -583,9 +599,35 @@ func (e *Engine) runBin() error {
 	return nil
 }
 
+func (e *Engine) stopBin() {
+
+	exitCode := make(chan int)
+	wasRunning := false
+
+	e.withLock(func() {
+		if e.binStopCh != nil {
+			wasRunning = true
+			e.mainDebug("sending shutdown command to killfunc")
+			e.binStopCh <- exitCode
+			e.binStopCh = nil
+		} else {
+			close(exitCode)
+		}
+	})
+
+	if ret := <-exitCode; ret != 0 {
+		os.Exit(ret)
+	}
+
+	if wasRunning {
+		e.mainDebug("stopBin done")
+	}
+}
+
 func (e *Engine) cleanup() {
 	e.mainLog("cleaning...")
 	defer e.mainLog("see you again~")
+	defer e.mainDebug("exited")
 
 	if e.config.Proxy.Enabled {
 		e.mainDebug("powering down the proxy...")
@@ -594,11 +636,8 @@ func (e *Engine) cleanup() {
 		}
 	}
 
-	e.withLock(func() {
-		close(e.binStopCh)
-		e.binStopCh = make(chan bool)
-	})
-	e.mainDebug("waiting for	close watchers..")
+	e.stopBin()
+	e.mainDebug("waiting for close watchers..")
 
 	e.withLock(func() {
 		for i := 0; i < int(e.watchers); i++ {
@@ -621,10 +660,7 @@ func (e *Engine) cleanup() {
 		}
 	}
 
-	e.mainDebug("waiting for exit...")
-	e.procKillWg.Wait()
-	e.running = false
-	e.mainDebug("exited")
+	e.running.Store(false)
 }
 
 // Stop the air

--- a/runner/engine_test.go
+++ b/runner/engine_test.go
@@ -863,7 +863,7 @@ func Test(t *testing.T) {
 	}
 	// check is MacOS
 	var cmd *exec.Cmd
-	var toolName string = "sed"
+	toolName := "sed"
 
 	if runtime.GOOS == "darwin" {
 		toolName = "gsed"

--- a/runner/engine_test.go
+++ b/runner/engine_test.go
@@ -337,7 +337,7 @@ func TestCtrlCWhenHaveKillDelay(t *testing.T) {
 		t.Fatalf("Should not be fail: %s.", err)
 	}
 	time.Sleep(time.Second * 3)
-	assert.False(t, engine.running)
+	assert.False(t, engine.running.Load())
 }
 
 func TestCtrlCWhenREngineIsRunning(t *testing.T) {
@@ -373,7 +373,7 @@ func TestCtrlCWhenREngineIsRunning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Should not be fail: %s.", err)
 	}
-	assert.False(t, engine.running)
+	assert.False(t, engine.running.Load())
 }
 
 func TestCtrlCWithFailedBin(t *testing.T) {
@@ -451,7 +451,7 @@ func TestFixCloseOfChannelAfterCtrlC(t *testing.T) {
 	if err := waitingPortConnectionRefused(t, port, time.Second*10); err != nil {
 		t.Fatalf("Should not be fail: %s.", err)
 	}
-	assert.False(t, engine.running)
+	assert.False(t, engine.running.Load())
 }
 
 func TestFixCloseOfChannelAfterTwoFailedBuild(t *testing.T) {
@@ -494,7 +494,7 @@ func TestFixCloseOfChannelAfterTwoFailedBuild(t *testing.T) {
 	// ctrl + c
 	sigs <- syscall.SIGINT
 	time.Sleep(time.Second * 1)
-	assert.False(t, engine.running)
+	assert.False(t, engine.running.Load())
 }
 
 // waitingPortReady waits until the port is ready to be used.
@@ -863,15 +863,17 @@ func Test(t *testing.T) {
 	}
 	// check is MacOS
 	var cmd *exec.Cmd
+	var toolName string = "sed"
+
 	if runtime.GOOS == "darwin" {
-		cmd = exec.Command("gsed", "-i", "s/\"_test.*go\"//g", ".air.toml")
-	} else {
-		cmd = exec.Command("sed", "-i", "s/\"_test.*go\"//g", ".air.toml")
+		toolName = "gsed"
 	}
+
+	cmd = exec.Command(toolName, "-i", "s/\"_test.*go\"//g", ".air.toml")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		t.Fatal(err)
+		t.Skipf("unable to run %s, make sure the tool is installed to run this test", toolName)
 	}
 
 	time.Sleep(time.Second * 2)


### PR DESCRIPTION
This PR attempts to fix #669 by reworking how the killFunc is signalled that a shutdown has been requested.

Instead of reading directly from e.binStopCh (that creates a data race with the writer) it closes on a returned shutdown channel that is used from a new mutexed e.stopBin() func. The shutdown channel takes a channel of int, where the int is the "exit code" passed back to the requestor. It isn't actually the exit code of the process, but a code that can be (and currently is) used to os.Exit the entire process if shutdown failed.

The atomic.Bool change is unrelated to the actual issue, but was required to be able to run the unit tests with -race to detect if there were any races between all the channels and goroutine handling going on in this code.

Reading through the issue list there is a good possibility that this PR will fix, or considerably reduce, the problems seen in #640 #492 #334 and do away with the need for #131 .

This PR has been unit tested and development tested on wsl2 linux and an Apple M2 MBP.