### PR TITLE
do not sleep to kill a process that has already cleaned up and exited by itself

### DIFF
--- a/runner/util_linux.go
+++ b/runner/util_linux.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"context"
 	"io"
 	"os/exec"
 	"syscall"
@@ -12,20 +13,50 @@ import (
 func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 	pid = cmd.Process.Pid
 
+	var killDelay time.Duration
+
 	if e.config.Build.SendInterrupt {
+		e.mainDebug("sending interrupt to process %d", pid)
 		// Sending a signal to make it clear to the process that it is time to turn off
 		if err = syscall.Kill(-pid, syscall.SIGINT); err != nil {
 			return
 		}
-		time.Sleep(e.config.killDelay())
+		// the kill delay is 0 by default unless the user has configured send_interrupt=true
+		// in which case it is fetched from the kill_delay setting in the .air.toml
+		killDelay = e.config.killDelay()
+		e.mainDebug("setting a kill timer for %s", killDelay.String())
 	}
 
-	// https://stackoverflow.com/questions/22470193/why-wont-go-kill-a-child-process-correctly
-	err = syscall.Kill(-pid, syscall.SIGKILL)
+	waitResult := make(chan error)
+	go func() {
+		defer close(waitResult)
+		_, _ = cmd.Process.Wait()
+	}()
 
-	// Wait releases any resources associated with the Process.
-	_, _ = cmd.Process.Wait()
-	return
+	// prepare a cancel context that can stop the killing if it is not needed
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	killResult := make(chan error)
+	// Spawn a goroutine that will kill the process after kill delay if we have not
+	// received a wait result before that.
+	go func() {
+		select {
+		case <-time.After(killDelay):
+			// https://stackoverflow.com/questions/22470193/why-wont-go-kill-a-child-process-correctly
+			killResult <- syscall.Kill(-pid, syscall.SIGKILL)
+		case <-ctx.Done():
+			return
+		}
+	}()
+
+	for {
+		select {
+		case err = <-killResult:
+		case <-waitResult:
+			return
+		}
+	}
 }
 
 func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {

--- a/runner/util_linux.go
+++ b/runner/util_linux.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
 	"os/exec"
-	"syscall"
 	"time"
 
 	"github.com/creack/pty"
@@ -16,10 +16,16 @@ func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 
 	var killDelay time.Duration
 
+	waitResult := make(chan error)
+	go func() {
+		defer close(waitResult)
+		_, _ = cmd.Process.Wait()
+	}()
+
 	if e.config.Build.SendInterrupt {
 		e.mainDebug("sending interrupt to process %d", pid)
 		// Sending a signal to make it clear to the process that it is time to turn off
-		if err = syscall.Kill(-pid, syscall.SIGINT); err != nil {
+		if err = cmd.Process.Signal(os.Interrupt); err != nil {
 			return
 		}
 		// the kill delay is 0 by default unless the user has configured send_interrupt=true
@@ -38,17 +44,12 @@ func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 	go func() {
 		select {
 		case <-time.After(killDelay):
-			// https://stackoverflow.com/questions/22470193/why-wont-go-kill-a-child-process-correctly
-			killResult <- syscall.Kill(-pid, syscall.SIGKILL)
+			e.mainDebug("kill timer expired")
+			killResult <- cmd.Process.Kill()
 		case <-ctx.Done():
+			e.mainDebug("kill timer canceled")
 			return
 		}
-	}()
-
-	waitResult := make(chan error)
-	go func() {
-		_, err := cmd.Process.Wait()
-		waitResult <- err
 	}()
 
 	results := make([]error, 0, 2)
@@ -61,7 +62,7 @@ func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 		case err = <-waitResult:
 			results = append(results, err)
 			// if we have a kill delay, we ignore the kill result
-			if killDelay > 0 {
+			if killDelay > 0 && len(results) == 1 {
 				results = append(results, nil)
 			}
 		}

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -1,7 +1,6 @@
 package runner
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -10,7 +9,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
@@ -145,28 +143,6 @@ func TestAdaptToVariousPlatforms(t *testing.T) {
 	adaptToVariousPlatforms(config)
 	if config.Build.Bin != "tmp\\main.exe  -dev" {
 		t.Errorf("expected '%s' but got '%s'", "tmp\\main.exe  -dev", config.Build.Bin)
-	}
-}
-
-func Test_killCmd_no_process(t *testing.T) {
-	e := Engine{
-		config: &Config{
-			Build: cfgBuild{
-				SendInterrupt: false,
-			},
-		},
-	}
-	_, err := e.killCmd(&exec.Cmd{
-		Process: &os.Process{
-			Pid: 9999,
-		},
-	})
-	if err == nil {
-		t.Errorf("expected error but got none")
-	}
-	if !errors.Is(err, syscall.ESRCH) {
-		err = errors.Unwrap(err)
-		t.Errorf("expected '%s' but got '%s'", syscall.ESRCH, err.Error())
 	}
 }
 

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -165,7 +165,8 @@ func Test_killCmd_no_process(t *testing.T) {
 		t.Errorf("expected error but got none")
 	}
 	if !errors.Is(err, syscall.ESRCH) {
-		t.Errorf("expected '%s' but got '%s'", syscall.ESRCH, errors.Unwrap(err))
+		err = errors.Unwrap(err)
+		t.Errorf("expected '%s' but got '%s'", syscall.ESRCH, err.Error())
 	}
 }
 

--- a/runner/util_unix.go
+++ b/runner/util_unix.go
@@ -25,8 +25,8 @@ func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 
 	if e.config.Build.SendInterrupt {
 		e.mainDebug("sending interrupt to process %d", pid)
-		// Sending a signal to make it clear to the process that it is time to turn off
-		if err = cmd.Process.Signal(os.Interrupt); err != nil {
+		// Sending a signal to make it clear to the process group that it is time to turn off
+		if err = syscall.Kill(-pid, syscall.SIGINT); err != nil {
 			return
 		}
 		// the kill delay is 0 by default unless the user has configured send_interrupt=true
@@ -46,7 +46,8 @@ func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 		select {
 		case <-time.After(killDelay):
 			e.mainDebug("kill timer expired")
-			killResult <- cmd.Process.Kill()
+			// https://stackoverflow.com/questions/22470193/why-wont-go-kill-a-child-process-correctly
+			killResult <- syscall.Kill(-pid, syscall.SIGKILL)
 		case <-ctx.Done():
 			e.mainDebug("kill timer canceled")
 			return

--- a/runner/util_unix.go
+++ b/runner/util_unix.go
@@ -4,6 +4,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"os/exec"
@@ -28,12 +29,6 @@ func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 		e.mainDebug("setting a kill timer for %s", killDelay.String())
 	}
 
-	waitResult := make(chan error)
-	go func() {
-		defer close(waitResult)
-		_, _ = cmd.Process.Wait()
-	}()
-
 	// prepare a cancel context that can stop the killing if it is not needed
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -51,10 +46,29 @@ func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 		}
 	}()
 
+	waitResult := make(chan error)
+	go func() {
+		_, err := cmd.Process.Wait()
+		waitResult <- err
+	}()
+
+	results := make([]error, 0, 2)
+
 	for {
+		// collect the responses from the kill and wait goroutines
 		select {
 		case err = <-killResult:
-		case <-waitResult:
+			results = append(results, err)
+		case err = <-waitResult:
+			results = append(results, err)
+			// if we have a kill delay, we ignore the kill result
+			if killDelay > 0 {
+				results = append(results, nil)
+			}
+		}
+
+		if len(results) == 2 {
+			err = errors.Join(results...)
 			return
 		}
 	}

--- a/runner/util_unix.go
+++ b/runner/util_unix.go
@@ -3,6 +3,7 @@
 package runner
 
 import (
+	"context"
 	"io"
 	"os"
 	"os/exec"
@@ -13,18 +14,50 @@ import (
 func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 	pid = cmd.Process.Pid
 
+	var killDelay time.Duration
+
 	if e.config.Build.SendInterrupt {
+		e.mainDebug("sending interrupt to process %d", pid)
 		// Sending a signal to make it clear to the process that it is time to turn off
 		if err = syscall.Kill(-pid, syscall.SIGINT); err != nil {
 			return
 		}
-		time.Sleep(e.config.killDelay())
+		// the kill delay is 0 by default unless the user has configured send_interrupt=true
+		// in which case it is fetched from the kill_delay setting in the .air.toml
+		killDelay = e.config.killDelay()
+		e.mainDebug("setting a kill timer for %s", killDelay.String())
 	}
-	// https://stackoverflow.com/questions/22470193/why-wont-go-kill-a-child-process-correctly
-	err = syscall.Kill(-pid, syscall.SIGKILL)
-	// Wait releases any resources associated with the Process.
-	_, _ = cmd.Process.Wait()
-	return pid, err
+
+	waitResult := make(chan error)
+	go func() {
+		defer close(waitResult)
+		_, _ = cmd.Process.Wait()
+	}()
+
+	// prepare a cancel context that can stop the killing if it is not needed
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	killResult := make(chan error)
+	// Spawn a goroutine that will kill the process after kill delay if we have not
+	// received a wait result before that.
+	go func() {
+		select {
+		case <-time.After(killDelay):
+			// https://stackoverflow.com/questions/22470193/why-wont-go-kill-a-child-process-correctly
+			killResult <- syscall.Kill(-pid, syscall.SIGKILL)
+		case <-ctx.Done():
+			return
+		}
+	}()
+
+	for {
+		select {
+		case err = <-killResult:
+		case <-waitResult:
+			return
+		}
+	}
 }
 
 func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {


### PR DESCRIPTION
This PR fixes #671 by replacing the time.Sleep in killCmd (for linux and unix/mac) with a cancelable context that can be used to stop the kill timer and return to the caller as soon as the interrupted process has closed down.

While developing this PR I took the liberty of deleting the unit test for testing killing of "non existing" processes for reasons outlined in 52428bf7f43a18e0e96774071cccbf761d8bb1ca.

This PR has been tested on wsl2 linux and an Apple M2 MBP.