### PR TITLE
replace io.Copy with a scanner to avoid output related deadlocks on WSL2

### DIFF
--- a/runner/engine.go
+++ b/runner/engine.go
@@ -435,8 +435,8 @@ func (e *Engine) runCommand(command string) error {
 		stderr.Close()
 	}()
 
-	go copyOutput(os.Stdout, stdout)
-	go copyOutput(os.Stderr, stderr)
+	copyOutput(os.Stdout, stdout)
+	copyOutput(os.Stderr, stderr)
 
 	// wait for command to finish
 	return cmd.Wait()

--- a/runner/util.go
+++ b/runner/util.go
@@ -1,9 +1,11 @@
 package runner
 
 import (
+	"bufio"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -204,6 +206,13 @@ func (e *Engine) logWithLock(f func()) {
 	e.ll.Lock()
 	f()
 	e.ll.Unlock()
+}
+
+func copyOutput(dst io.Writer, src io.Reader) {
+	scanner := bufio.NewScanner(src)
+	for scanner.Scan() {
+		dst.Write([]byte(scanner.Text() + "\n"))
+	}
 }
 
 func expandPath(path string) (string, error) {


### PR DESCRIPTION
This PR is a fix for #673 

I have no clear idea what the actual problem is here, but deadlocks are very frequent when running the unit tests under WSL2 and seem to be related to the use of io.Copy to copy stdout and stderr

A deadlock occurs when multiple goroutines get parked indefinitely waiting for an rwlock deep down in the posix file system to be able to write to stdout...

Before merging, please check the change in runCommand. Is there a reason why this copying is synchronous (all of stdout before starting to copy stderr) or should they be asynchronous coroutines just as in runBin?