### PR TITLE
refactor: simplify test asserts; enable testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,5 +12,6 @@ linters:
     - revive # configurable linter for Go. Drop-in replacement of golint
     - staticcheck # go vet on steroids
     - stylecheck # static analysis, finds bugs and performance issues, offers simplifications, and enforces style rules
+    - testifylint # checks usage of github.com/stretchr/testify
     - unconvert # Remove unnecessary type conversions
     - unused # Checks Go code for unused constants, variables, functions and types

--- a/runner/flag_test.go
+++ b/runner/flag_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFlag(t *testing.T) {
@@ -54,7 +55,7 @@ func TestFlag(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			flag := flag.NewFlagSet(t.Name(), flag.ExitOnError)
 			cmdArgs := ParseConfigFlag(flag)
-			assert.NoError(t, flag.Parse(tc.args))
+			require.NoError(t, flag.Parse(tc.args))
 			assert.Equal(t, tc.expected, *cmdArgs[tc.key].Value)
 		})
 	}
@@ -98,7 +99,7 @@ func TestConfigRuntimeArgs(t *testing.T) {
 			args: []string{"--build.exclude_unchanged", "true"},
 			key:  "build.exclude_unchanged",
 			check: func(t *testing.T, conf *Config) {
-				assert.Equal(t, true, conf.Build.ExcludeUnchanged)
+				assert.True(t, conf.Build.ExcludeUnchanged)
 			},
 		},
 		{
@@ -121,7 +122,7 @@ func TestConfigRuntimeArgs(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
-			assert.NoError(t, os.Chdir(dir))
+			require.NoError(t, os.Chdir(dir))
 			flag := flag.NewFlagSet(t.Name(), flag.ExitOnError)
 			cmdArgs := ParseConfigFlag(flag)
 			_ = flag.Parse(tc.args)

--- a/runner/proxy_test.go
+++ b/runner/proxy_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type reloader struct {
@@ -97,8 +98,8 @@ func TestProxy_proxyHandler(t *testing.T) {
 				return req
 			},
 			assert: func(resp *http.Request) {
-				assert.NoError(t, resp.ParseForm())
-				assert.Equal(t, resp.Form.Get("foo"), "bar")
+				require.NoError(t, resp.ParseForm())
+				assert.Equal(t, "bar", resp.Form.Get("foo"))
 			},
 		},
 		{
@@ -108,7 +109,7 @@ func TestProxy_proxyHandler(t *testing.T) {
 			},
 			assert: func(resp *http.Request) {
 				q := resp.URL.Query()
-				assert.Equal(t, q.Encode(), "q=air")
+				assert.Equal(t, "q=air", q.Encode())
 			},
 		},
 		{
@@ -124,9 +125,9 @@ func TestProxy_proxyHandler(t *testing.T) {
 					Foo string `json:"foo"`
 				}
 				var r Response
-				assert.NoError(t, json.NewDecoder(resp.Body).Decode(&r))
-				assert.Equal(t, resp.URL.Path, "/a/b/c")
-				assert.Equal(t, r.Foo, "bar")
+				require.NoError(t, json.NewDecoder(resp.Body).Decode(&r))
+				assert.Equal(t, "/a/b/c", resp.URL.Path)
+				assert.Equal(t, "bar", r.Foo)
 			},
 		},
 		{

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsDirRootPath(t *testing.T) {
@@ -219,7 +220,7 @@ func Test_killCmd_SendInterrupt_false(t *testing.T) {
 	// check processes were being killed
 	// read pids from file
 	bytesRead, err := os.ReadFile("pid")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	lines := strings.Split(string(bytesRead), "\n")
 	for _, line := range lines {
 		_, err := strconv.Atoi(line)
@@ -283,7 +284,7 @@ func TestCheckIncludeFile(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, e.checkIncludeFile("main.go"), true)
-	assert.Equal(t, e.checkIncludeFile("no.go"), false)
-	assert.Equal(t, e.checkIncludeFile("."), false)
+	assert.True(t, e.checkIncludeFile("main.go"))
+	assert.False(t, e.checkIncludeFile("no.go"))
+	assert.False(t, e.checkIncludeFile("."))
 }


### PR DESCRIPTION
The PR refactors tests by simplifying asserts: swap actual-expected parameters, use `assert.True`, `assert.False`, `require.Error` etc. Additionally, enables `testifylint` to suggests these in a future.