### PR TITLE
refactor: remove unnecessary var copy in for

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ run:
 linters:
   disable-all: true
   enable:
+    - copyloopvar # detects places where loop variables are copied
     - errcheck # Errcheck is a program for checking for unchecked errors in go programs.
     - gci # Gci controls Go package import order and makes it always deterministic
     - goimports # checks that goimports was run

--- a/runner/config_test.go
+++ b/runner/config_test.go
@@ -93,7 +93,6 @@ func TestDefaultPathConfig(t *testing.T) {
 	}}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv(airWd, tt.path)
 			c, err := defaultPathConfig()


### PR DESCRIPTION
The PR removes unneeded in Go 1.23 `tt := tt` and enables `copyloopvar` linter to detect that in the future. See https://go.dev/blog/loopvar-preview