### PR TITLE
Update unclear .profile changes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ services:
 ```shell
 export GOPATH=$HOME/xxxxx
 export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
-export PATH=$PATH:$(go env GOPATH)/bin <---- Confirm this line in you profile!!!
+export PATH=$PATH:$(go env GOPATH)/bin #Confirm this line in your .profile and make sure to source the .profile if you add it!!!
 ```
 
 ### Error under wsl when ' is included in the bin


### PR DESCRIPTION
I was trying to install the AIR on my fresh new machine with bash, 
and as I am new to bash environment, I didn't knew that we have to source the .profile if I add missing bin path. 
It would be great to make it more clear and newbie friendly instruction.

Hence proposing the changes in documentation for better clarity.