### PR TITLE
fix: default config overwrite

### DIFF
--- a/runner/config.go
+++ b/runner/config.go
@@ -387,7 +387,9 @@ func (c *Config) rel(path string) string {
 // WithArgs returns a new config with the given arguments added to the configuration.
 func (c *Config) WithArgs(args map[string]TomlInfo) {
 	for _, value := range args {
-		if value.Value != nil && *value.Value != unsetDefault {
+		// Ignore values that match the default configuration.
+		// This ensures user-specified configurations are not overwritten by default values.
+		if value.Value != nil && *value.Value != value.fieldValue {
 			v := reflect.ValueOf(c)
 			setValue2Struct(v, value.fieldPath, *value.Value)
 		}

--- a/runner/flag.go
+++ b/runner/flag.go
@@ -4,8 +4,6 @@ import (
 	"flag"
 )
 
-const unsetDefault = "DEFAULT"
-
 // ParseConfigFlag parse toml information for flag
 func ParseConfigFlag(f *flag.FlagSet) map[string]TomlInfo {
 	c := defaultConfig()


### PR DESCRIPTION
This PR fixes #718.

After the v1.61.4 release, the user-specified config is overwritten by default values

This commit introduced a bug: 

https://github.com/air-verse/air/commit/c8498c261b0ad39cebc0131952db299018847d08#diff-19e19f16fa5018b7ad46fc960cdbe0138b0029dac020b42c798a9ff9b8203493R14

---

Initial configuration is updated with command line args:

https://github.com/air-verse/air/blob/master/main.go#L97

but, when `defaultConfig` is used in 

https://github.com/air-verse/air/blob/master/runner/flag.go#L9-L17

all command line values are set to default, effectively overwriting everything from user-specified `.air.toml`.

This PR ensures that only command-line arguments that differ from default values overwrite the config. This is safe since the initial config is based on the default and the user’s .air.toml.

