### PR TITLE
Feature: Show build errors when using proxy

### DIFF
--- a/runner/engine.go
+++ b/runner/engine.go
@@ -395,14 +395,17 @@ func (e *Engine) buildRun() {
 		e.buildLog("failed to build, error: %s", err.Error())
 		_ = e.writeBuildErrorLog(err.Error())
 		if e.config.Build.StopOnError {
+			// It only makes sense to run it if we stop on error. Otherwise when
+			// running the binary again the error modal will be overwritten by
+			// the reload.
+			if e.config.Proxy.Enabled {
+				e.proxy.BuildFailed(BuildFailedMsg{
+					Error:   err.Error(),
+					Command: e.config.Build.Cmd,
+					Output:  output,
+				})
+			}
 			return
-		}
-		if e.config.Proxy.Enabled {
-			e.proxy.BuildFailed(BuildFailedMsg{
-				Error:   err.Error(),
-				Command: e.config.Build.Cmd,
-				Output:  output,
-			})
 		}
 	}
 

--- a/runner/proxy.js
+++ b/runner/proxy.js
@@ -1,0 +1,14 @@
+(() => {
+    const eventSource = new EventSource("/__air_internal/sse")
+
+    eventSource.addEventListener('reload', () => {
+        location.reload();
+    });
+
+    eventSource.addEventListener('build-failed', (event) => {
+        const data = JSON.parse(event.data);
+        console.error('Error en la construcción:', data.command);
+        console.error('Salida estándar:', data.output);
+        console.error('Error estándar:', data.error);
+    });
+})()

--- a/runner/proxy.js
+++ b/runner/proxy.js
@@ -1,5 +1,5 @@
 (() => {
-    const eventSource = new EventSource("/__air_internal/sse")
+    const eventSource = new EventSource("/__air_internal/sse");
 
     eventSource.addEventListener('reload', () => {
         location.reload();
@@ -7,8 +7,80 @@
 
     eventSource.addEventListener('build-failed', (event) => {
         const data = JSON.parse(event.data);
-        console.error('Error en la construcción:', data.command);
-        console.error('Salida estándar:', data.output);
-        console.error('Error estándar:', data.error);
+        showErrorInModal(data);
     });
-})()
+
+    function showErrorInModal(data) {
+        document.body.insertAdjacentHTML(`beforeend`, `
+            <style>
+                .air__modal {
+                    display: none;
+                    position: fixed;
+                    z-index: 1000;
+                    left: 0;
+                    top: 0;
+                    width: 100%;
+                    height: 100%;
+                    background-color: rgba(0, 0, 0, 0.5);
+                    justify-content: center;
+                    align-items: center;
+                }
+                .air__modal-content {
+                    background-color: white;
+                    color: black;
+                    padding: 20px;
+                    border-radius: 5px;
+                    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+                    width: 80%;
+                }
+                .air__modal-header {
+                    font-size: 1.5em;
+                    margin-bottom: 10px;
+                }
+                .air__modal-body {
+                    margin-bottom: 20px;
+                    overflow-x: auto;
+                }
+                .air__modal-close {
+                    background-color: #007bff;
+                    color: white;
+                    border: none;
+                    padding: 10px 15px;
+                    border-radius: 5px;
+                    cursor: pointer;
+                }
+                .air__modal pre {
+                    background-color: #1e1e1e;
+                    color: #f8f8f2;
+                    padding: 10px;
+                    border-radius: 5px;
+                    overflow-x: auto;
+                    white-space: pre;
+                }
+                .air__modal code {
+                    font-family: 'Courier New', Courier, monospace;
+                }
+            </style>
+            <div class="air__modal" id="air__modal">
+                <div class="air__modal-content">
+                    <div class="air__modal-header">Build Error</div>
+                    <div class="air__modal-body" id="air__modal-body"></div>
+                    <button class="air__modal-close" id="air__modal-close">Close</button>
+                </div>
+            </div>
+        `);
+        const modal = document.getElementById('air__modal');
+        const modalBody = document.getElementById('air__modal-body');
+        const modalClose = document.getElementById('air__modal-close');
+        modalBody.innerHTML = `
+            <strong>Build Cmd:</strong> <pre><code>${data.command}</code></pre><br>
+            <strong>Output:</strong> <pre><code>${data.output}</code></pre><br>
+            <strong>Error:</strong> <pre><code>${data.error}</code></pre>
+        `;
+        modal.style.display = 'flex';
+
+        modalClose.addEventListener('click', () => {
+            modal.style.display = 'none';
+        });
+    }
+})();

--- a/runner/proxy_stream.go
+++ b/runner/proxy_stream.go
@@ -15,8 +15,8 @@ type ProxyStream struct {
 type StreamMessageType string
 
 const (
-	StreamMessageReload StreamMessageType = "reload"
-	StreamMessageError  StreamMessageType = "error"
+	StreamMessageReload      StreamMessageType = "reload"
+	StreamMessageBuildFailed StreamMessageType = "build-failed"
 )
 
 type StreamMessage struct {
@@ -24,10 +24,10 @@ type StreamMessage struct {
 	Data interface{}
 }
 
-type StreamErrorMessage struct {
+type BuildFailedMsg struct {
+	Error   string `json:"error"`
 	Command string `json:"command"`
-	Stdout  string `json:"stdout"`
-	Stderr  string `json:"stderr"`
+	Output  string `json:"output"`
 }
 
 type Subscriber struct {
@@ -75,10 +75,10 @@ func (stream *ProxyStream) Reload() {
 	}
 }
 
-func (stream *ProxyStream) Error(err StreamErrorMessage) {
+func (stream *ProxyStream) BuildFailed(err BuildFailedMsg) {
 	for _, sub := range stream.subscribers {
 		sub.msgCh <- StreamMessage{
-			Type: StreamMessageError,
+			Type: StreamMessageBuildFailed,
 			Data: err,
 		}
 	}

--- a/runner/proxy_stream.go
+++ b/runner/proxy_stream.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"encoding/json"
+	"fmt"
 	"sync"
 	"sync/atomic"
 )
@@ -91,6 +92,9 @@ func (m StreamMessage) AsSSE() string {
 }
 
 func stringify(v any) string {
-	b, _ := json.Marshal(v)
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("{\"error\":\"Failed to marshal message: %s\"}", err)
+	}
 	return string(b)
 }

--- a/runner/proxy_stream_test.go
+++ b/runner/proxy_stream_test.go
@@ -43,7 +43,7 @@ func TestProxyStream(t *testing.T) {
 		wg.Add(1)
 		go func(sub *Subscriber) {
 			defer wg.Done()
-			<-sub.reloadCh
+			<-sub.msgCh
 			reloadCount.Add(1)
 		}(sub)
 	}

--- a/runner/proxy_stream_test.go
+++ b/runner/proxy_stream_test.go
@@ -4,6 +4,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func find(s map[int32]*Subscriber, id int32) bool {
@@ -68,4 +70,21 @@ func TestProxyStream(t *testing.T) {
 	if got, exp := len(stream.subscribers), 0; got != exp {
 		t.Errorf("expected subscribers count to be %d, got %d", exp, got)
 	}
+}
+
+func TestBuildFailureMessage(t *testing.T) {
+	stream := NewProxyStream()
+	sub := stream.AddSubscriber()
+
+	msg := BuildFailedMsg{
+		Error:   "build failed",
+		Command: "go build",
+		Output:  "error output",
+	}
+
+	go stream.BuildFailed(msg)
+
+	received := <-sub.msgCh
+	assert.Equal(t, StreamMessageBuildFailed, received.Type)
+	assert.Equal(t, msg, received.Data)
 }

--- a/runner/proxy_test.go
+++ b/runner/proxy_test.go
@@ -32,9 +32,9 @@ func (r *reloader) RemoveSubscriber(_ int32) {
 	close(r.subCh)
 }
 
-func (r *reloader) Reload()                  {}
-func (r *reloader) Error(StreamErrorMessage) {}
-func (r *reloader) Stop()                    {}
+func (r *reloader) Reload()                    {}
+func (r *reloader) BuildFailed(BuildFailedMsg) {}
+func (r *reloader) Stop()                      {}
 
 var proxyPort = 8090
 

--- a/runner/proxy_test.go
+++ b/runner/proxy_test.go
@@ -202,7 +202,7 @@ func TestProxy_injectLiveReload(t *testing.T) {
 				},
 				Body: io.NopCloser(strings.NewReader(`<body><h1>test</h1></body>`)),
 			},
-			expect: `<body><h1>test</h1><script>new EventSource("/internal/reload").onmessage = () => { location.reload() }</script></body>`,
+			expect: fmt.Sprintf(`<body><h1>test</h1><script>%s</script></body>`, ProxyScript),
 		},
 	}
 	for _, tt := range tests {
@@ -212,8 +212,15 @@ func TestProxy_injectLiveReload(t *testing.T) {
 				ProxyPort: 1111,
 				AppPort:   2222,
 			})
-			if got, _ := proxy.injectLiveReload(tt.given); got != tt.expect {
-				t.Errorf("expected page %+v, got %v", tt.expect, got)
+			got, _ := proxy.injectLiveReload(tt.given)
+			if got != tt.expect {
+				// Use a more descriptive error message
+				if len(got) > 100 || len(tt.expect) > 100 {
+					t.Errorf("Script injection mismatch.\nGot length: %d\nExpected length: %d",
+						len(got), len(tt.expect))
+				} else {
+					t.Errorf("expected page %+v, got %v", tt.expect, got)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
This is a feature that I missed when coming from the Javascript wold.

And, being relatively new to Go, having the build fail and testing the fronted with and old version of the program made me lose a good amount of time before I noticed.

Being new to open source and Go I'm sure that this PR will need more work, so I'll appreciate any feedback.

Thanks in advance.

Example:
![image](https://github.com/user-attachments/assets/433ec3f5-9a16-4cb4-9f04-68b10d9c6cea)
