### PR TITLE
Update README.MD Usage section with install location troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,18 @@ this will replace `$PWD` with the current directory, `$AIR_PORT` is the port whe
 
 ## Usage
 
-For less typing, you could add `alias air='~/.air'` to your `.bashrc` or `.zshrc`.
+For less typing, the following commands use a shell alias that can added to your `.bashrc` or `.zshrc`:
+```zsh
+  # Create Alias
+  alias air='~/.air'
+
+  # Test Alias
+  air -v
+
+  # Troubleshooting note: Install location varies depending on installation method. Modify alias as needed.
+  # For installations via `go install`, check `~/go/bin/air`.
+```
+
 
 First enter into your project
 


### PR DESCRIPTION
Beyond what is in the PR title, I also wanted to make clear that all the subsequent commands were using the alias provided.

The troubleshooting note is the result of my own troubleshooting. For me, there was no `~/.air`, but I was able to run the command `~/go/bin/air -v`, and modifying the alias accordingly worked.

The primary factor in the install location difference was almost certainly that I used `go install` to install. Other factors may have been my current go version (1.23.5) or my hardware (Apple Silicon), but these factors are less likely.