### PR TITLE
Resolve root directory if symlinked

### DIFF
--- a/runner/config.go
+++ b/runner/config.go
@@ -560,7 +560,7 @@ func (c *Config) preprocess(args map[string]TomlInfo) error {
 		if err = os.Chdir(cwd); err != nil {
 			return err
 		}
-		c.Root = cwd
+		c.Root = "."
 	}
 	c.Root, err = expandPath(c.Root)
 	if err != nil {

--- a/runner/config.go
+++ b/runner/config.go
@@ -560,7 +560,7 @@ func (c *Config) preprocess(args map[string]TomlInfo) error {
 		if err = os.Chdir(cwd); err != nil {
 			return err
 		}
-		c.Root = "."
+		c.Root = cwd
 	}
 	c.Root, err = expandPath(c.Root)
 	if err != nil {

--- a/runner/config_test.go
+++ b/runner/config_test.go
@@ -172,6 +172,10 @@ func TestEntrypointResolvesAbsolutePath(t *testing.T) {
 	}
 
 	want := filepath.Join(rootWithSpace, "tmp", "main")
+	// expandPath resolves symlinks; t.TempDir() may return a symlinked path on some OSs
+	if resolved, err := filepath.EvalSymlinks(filepath.Dir(want)); err == nil {
+		want = filepath.Join(resolved, filepath.Base(want))
+	}
 	if got := cfg.Build.Entrypoint.binary(); got != want {
 		t.Fatalf("entrypoint is %s, but want %s", got, want)
 	}
@@ -231,6 +235,10 @@ func TestEntrypointPreservesArgs(t *testing.T) {
 	}
 
 	wantBin := filepath.Join(root, "tmp", "main")
+	// expandPath resolves symlinks; t.TempDir() may return a symlinked path on some OSs
+	if resolved, err := filepath.EvalSymlinks(root); err == nil {
+		wantBin = filepath.Join(resolved, "tmp", "main")
+	}
 	if cfg.Build.Entrypoint.binary() != wantBin {
 		t.Fatalf("entrypoint binary is %s, want %s", cfg.Build.Entrypoint.binary(), wantBin)
 	}
@@ -535,8 +543,7 @@ func TestBuildOverridesFromDiff(t *testing.T) {
 	got := buildOverridesFromDiff(base, target)
 	if got == nil {
 		t.Fatal("expected non-nil override for changed configs")
-	}
-	if !reflect.DeepEqual(got.PreCmd, target.PreCmd) {
+	} else if !reflect.DeepEqual(got.PreCmd, target.PreCmd) {
 		t.Fatalf("pre_cmd mismatch: got %v want %v", got.PreCmd, target.PreCmd)
 	}
 	if got.Cmd != target.Cmd {

--- a/runner/util.go
+++ b/runner/util.go
@@ -271,6 +271,7 @@ func expandPath(path string) (string, error) {
 
 // Dereferences a symbolic link to its relative path.
 // If the path is not a symlink, simply returns the path.
+// If the file does not exist, return the path and no err.
 func derefLink(path string) (string, error) {
 	ok, err := isSymlink(path)
 	if err != nil {

--- a/runner/util.go
+++ b/runner/util.go
@@ -276,20 +276,17 @@ func expandPath(path string) (string, error) {
 
 	expanded, err := filepath.Abs(expanded)
 	if err != nil {
-		return "", fmt.Errorf("Error getting absolute path to %v: %v", expanded, err)
+		return "", fmt.Errorf("error getting absolute path to %v: %w", expanded, err)
 	}
 
 	// filepath.EvalSymlinks only works on real files
 	dereferenced, err := filepath.EvalSymlinks(expanded)
-	if err != nil {
-		// The error is something more serious than the path not existing, fail.
-		if !errors.Is(err, fs.ErrNotExist) {
-			return "", fmt.Errorf("Unexpected error while dereferencing %v: %v", expanded, err)
-		}
-	} else {
-		// The error is simply that the path is not a real file.
-		// Continue without dereferencing.
-		expanded = dereferenced
+	if err == nil {
+		return dereferenced, nil
+	}
+
+	if !errors.Is(err, fs.ErrNotExist) {
+		return "", fmt.Errorf("unexpected error while dereferencing %v: %w", expanded, err)
 	}
 
 	return expanded, nil

--- a/runner/util.go
+++ b/runner/util.go
@@ -274,6 +274,9 @@ func expandPath(path string) (string, error) {
 func derefLink(path string) (string, error) {
 	ok, err := isSymlink(path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return path, nil
+		}
 		return "", err
 	}
 	if !ok {

--- a/runner/util.go
+++ b/runner/util.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
@@ -258,56 +259,40 @@ func copyOutput(dst io.Writer, src io.Reader) {
 	}
 }
 
+// Expands a path, resolving any tilde prefixes, dereferencing symbolic links,
+// and converting relative paths to absolute. The result will always be an
+// absolute path.
+// For paths that do not exist on the filesystem, the dereferencing step will
+// be skipped.
+// An error will be thrown if dereferencing fails due to something other than
+// the path not existing on the filesystem.
 func expandPath(path string) (string, error) {
+	expanded := path
+
 	if strings.HasPrefix(path, "~/") {
 		home := os.Getenv("HOME")
-		return home + path[1:], nil
+		expanded = filepath.Join(home, path[1:])
 	}
-	if (pathInfo.Mode() & os.ModeSymlink) != 0 {
-		return true, nil
-	}
-	return false, nil
-}
 
-// Dereferences a symbolic link to its relative path.
-// If the path is not a symlink, simply returns the path.
-// If the file does not exist, return the path and no err.
-func derefLink(path string) (string, error) {
-	ok, err := isSymlink(path)
+	expanded, err := filepath.Abs(expanded)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return path, nil
+		return "", fmt.Errorf("Error getting absolute path to %v: %v", expanded, err)
+	}
+
+	// filepath.EvalSymlinks only works on real files
+	dereferenced, err := filepath.EvalSymlinks(expanded)
+	if err != nil {
+		// The error is something more serious than the path not existing, fail.
+		if !errors.Is(err, fs.ErrNotExist) {
+			return "", fmt.Errorf("Unexpected error while dereferencing %v: %v", expanded, err)
 		}
-		return "", err
-	}
-	if !ok {
-		return path, nil
-	}
-
-	targetPath, err := filepath.EvalSymlinks(path)
-	if err != nil {
-		return "", err
-	}
-	absTargetPath, err := filepath.Abs(targetPath)
-	if err != nil {
-		return "", err
-	}
-	return absTargetPath, nil
-}
-
-// expandPath takes a path string (which may be absolute, relative, or tilde
-// expanded) and returns an absolute path to that file.
-func expandPath(path string) (string, error) {
-	if strings.HasPrefix(path, "~/") {
-		home := os.Getenv("HOME")
-		path = filepath.Join(home, path[1:])
+	} else {
+		// The error is simply that the path is not a real file.
+		// Continue without dereferencing.
+		expanded = dereferenced
 	}
 
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return "", err
-	}
-	return absPath, nil
+	return expanded, nil
 }
 
 func isDir(path string) bool {

--- a/runner/util.go
+++ b/runner/util.go
@@ -263,18 +263,47 @@ func expandPath(path string) (string, error) {
 		home := os.Getenv("HOME")
 		return home + path[1:], nil
 	}
-	var err error
-	wd, err := os.Getwd()
+	if (pathInfo.Mode() & os.ModeSymlink) != 0 {
+		return true, nil
+	}
+	return false, nil
+}
+
+// Dereferences a symbolic link to its relative path.
+// If the path is not a symlink, simply returns the path.
+func derefLink(path string) (string, error) {
+	ok, err := isSymlink(path)
 	if err != nil {
 		return "", err
 	}
-	if path == "." {
-		return wd, nil
+	if !ok {
+		return path, nil
 	}
-	if strings.HasPrefix(path, "./") {
-		return wd + path[1:], nil
+
+	targetPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", err
 	}
-	return path, nil
+	absTargetPath, err := filepath.Abs(targetPath)
+	if err != nil {
+		return "", err
+	}
+	return absTargetPath, nil
+}
+
+// expandPath takes a path string (which may be absolute, relative, or tilde
+// expanded) and returns an absolute path to that file.
+func expandPath(path string) (string, error) {
+	if strings.HasPrefix(path, "~/") {
+		home := os.Getenv("HOME")
+		path = filepath.Join(home, path[1:])
+	}
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	return absPath, nil
 }
 
 func isDir(path string) bool {

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -43,7 +43,7 @@ func TestIsDirFileNot(t *testing.T) {
 
 func TestExpandPathWithRelPath(t *testing.T) {
 	tmp := path.Join("_testdata", "tmp")
-	_, err := os.Create(tmp)
+	err := os.Mkdir(tmp, 0750)
 	defer os.Remove(tmp)
 	if err != nil {
 		t.Fatalf("Error creating temp directory for testing: %v", err)

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -42,15 +42,19 @@ func TestIsDirFileNot(t *testing.T) {
 }
 
 func TestExpandPathWithRelPath(t *testing.T) {
-	relPath := path.Join("_testdata", "toml", ".air.toml")
+	tmp := path.Join("_testdata", "tmp")
+	_, err := os.Create(tmp)
+	defer os.Remove(tmp)
+	if err != nil {
+		t.Fatalf("Error creating temp directory for testing: %v", err)
+	}
 
+	expandedPath, _ := expandPath("_testdata/tmp")
 	wd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("Error getting cwd: %v", err)
 	}
-
-	expandedPath, _ := expandPath(relPath)
-	expected := path.Join(wd, relPath)
+	expected := path.Join(wd, tmp)
 	if expandedPath != expected {
 		t.Errorf("expected %s got %s", expected, expandedPath)
 	}
@@ -66,7 +70,10 @@ func TestExpandPathWithDot(t *testing.T) {
 
 func TestExpandPathWithHomePath(t *testing.T) {
 	path := "~/.conf"
-	result, _ := expandPath(path)
+	result, err := expandPath(path)
+	if err != nil {
+		t.Errorf("expandPath returned an error: %v", err)
+	}
 	home := os.Getenv("HOME")
 	want := home + path[1:]
 	if result != want {
@@ -1035,5 +1042,82 @@ func TestIsDangerousRoot(t *testing.T) {
 				assert.Equal(t, tt.description, desc, "description mismatch for path %s", tt.path)
 			}
 		})
+	}
+}
+
+// Regression test for https://github.com/air-verse/air/issues/531. Makes sure
+// that if the project's root directory is a symlink, it will be correctly
+// expanded.
+func TestExpandPathRootDirectoryIsSymlink(t *testing.T) {
+	// Save the original working directory so we don't break other tests
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get original directory: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := os.Chdir(origDir); err != nil {
+			t.Errorf("Cleanup failed to restore original directory: %v", err)
+		}
+	})
+
+	tempDir := t.TempDir()
+
+	// Temp directories on some OSs (like macOS) are themselves symlinks.
+	// We need the fully resolved base directory to correctly construct our expected path.
+	realTempDir, err := filepath.EvalSymlinks(tempDir)
+	if err != nil {
+		t.Fatalf("Failed to resolve real temp dir: %v", err)
+	}
+
+	// Move into the temporary workspace to recreate the scenario
+	if err := os.Chdir(realTempDir); err != nil {
+		t.Fatalf("Failed to chdir to temp dir: %v", err)
+	}
+
+	// Create a nested directory structure ./foo/bar/
+	if err := os.MkdirAll(filepath.Join("foo", "bar"), 0755); err != nil {
+		t.Fatalf("Failed to create nested directories: %v", err)
+	}
+
+	// Create a file ./foo/bar/baz
+	if err := os.WriteFile(filepath.Join("foo", "bar", "baz"), []byte("dummy content"), 0644); err != nil {
+		t.Fatalf("Failed to create regular file baz: %v", err)
+	}
+
+	// Symlink ./bar -> ./foo/bar/
+	if err := os.Symlink(filepath.Join("foo", "bar"), "bar"); err != nil {
+		t.Fatalf("Failed to create symlink: %v", err)
+	}
+
+	// cd into ./bar
+	if err := os.Chdir("bar"); err != nil {
+		t.Fatalf("Failed to change directory into symlink: %v", err)
+	}
+
+	pwd, _ := os.Getwd()
+	t.Logf("pwd: %s\n", pwd)
+	files, _ := os.ReadDir(".")
+	for _, file := range files {
+		t.Logf("file: %v\n", file)
+	}
+
+	data, err := os.ReadFile("./baz")
+	if err != nil {
+		t.Fatalf("Error reading file: %v", err)
+	}
+	t.Logf("Contents: %s\n", data)
+
+	expectedPath := filepath.Join(realTempDir, "foo", "bar", "baz")
+
+	// expandPath should recognize that the current directory is a symlink,
+	// and dereference it fully to resolve the nested path.
+	gotPath, err := expandPath("./baz")
+	if err != nil {
+		t.Fatalf("expandPath returned an unexpected error: %v", err)
+	}
+
+	if gotPath != expectedPath {
+		t.Errorf("expandPath failed to correctly resolve the symlinked current directory.\nGot:  %s\nWant: %s", gotPath, expectedPath)
 	}
 }

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -1049,17 +1049,7 @@ func TestIsDangerousRoot(t *testing.T) {
 // that if the project's root directory is a symlink, it will be correctly
 // expanded.
 func TestExpandPathRootDirectoryIsSymlink(t *testing.T) {
-	// Save the original working directory so we don't break other tests
-	origDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Failed to get original directory: %v", err)
-	}
-
-	t.Cleanup(func() {
-		if err := os.Chdir(origDir); err != nil {
-			t.Errorf("Cleanup failed to restore original directory: %v", err)
-		}
-	})
+	t.Parallel()
 
 	tempDir := t.TempDir()
 
@@ -1070,54 +1060,36 @@ func TestExpandPathRootDirectoryIsSymlink(t *testing.T) {
 		t.Fatalf("Failed to resolve real temp dir: %v", err)
 	}
 
-	// Move into the temporary workspace to recreate the scenario
-	if err := os.Chdir(realTempDir); err != nil {
-		t.Fatalf("Failed to chdir to temp dir: %v", err)
-	}
-
-	// Create a nested directory structure ./foo/bar/
-	if err := os.MkdirAll(filepath.Join("foo", "bar"), 0755); err != nil {
+	fooBarDir := filepath.Join(realTempDir, "foo", "bar")
+	if err := os.MkdirAll(fooBarDir, 0755); err != nil {
 		t.Fatalf("Failed to create nested directories: %v", err)
 	}
 
-	// Create a file ./foo/bar/baz
-	if err := os.WriteFile(filepath.Join("foo", "bar", "baz"), []byte("dummy content"), 0644); err != nil {
+	// Create a file <realTempDir>/foo/bar/baz
+	bazFile := filepath.Join(fooBarDir, "baz")
+	if err := os.WriteFile(bazFile, []byte("dummy content"), 0644); err != nil {
 		t.Fatalf("Failed to create regular file baz: %v", err)
 	}
 
-	// Symlink ./bar -> ./foo/bar/
-	if err := os.Symlink(filepath.Join("foo", "bar"), "bar"); err != nil {
+	// Symlink <realTempDir>/bar -> <realTempDir>/foo/bar
+	symlinkDir := filepath.Join(realTempDir, "bar")
+	if err := os.Symlink(fooBarDir, symlinkDir); err != nil {
 		t.Fatalf("Failed to create symlink: %v", err)
 	}
 
-	// cd into ./bar
-	if err := os.Chdir("bar"); err != nil {
-		t.Fatalf("Failed to change directory into symlink: %v", err)
-	}
+	// The expected fully resolved absolute path is the real file location
+	expectedPath := bazFile
 
-	pwd, _ := os.Getwd()
-	t.Logf("pwd: %s\n", pwd)
-	files, _ := os.ReadDir(".")
-	for _, file := range files {
-		t.Logf("file: %v\n", file)
-	}
+	// Test expandPath by passing the absolute path via the symlink
+	// This removes the need to pretend our CWD is inside the symlink.
+	targetPath := filepath.Join(symlinkDir, "baz")
 
-	data, err := os.ReadFile("./baz")
-	if err != nil {
-		t.Fatalf("Error reading file: %v", err)
-	}
-	t.Logf("Contents: %s\n", data)
-
-	expectedPath := filepath.Join(realTempDir, "foo", "bar", "baz")
-
-	// expandPath should recognize that the current directory is a symlink,
-	// and dereference it fully to resolve the nested path.
-	gotPath, err := expandPath("./baz")
+	gotPath, err := expandPath(targetPath)
 	if err != nil {
 		t.Fatalf("expandPath returned an unexpected error: %v", err)
 	}
 
 	if gotPath != expectedPath {
-		t.Errorf("expandPath failed to correctly resolve the symlinked current directory.\nGot:  %s\nWant: %s", gotPath, expectedPath)
+		t.Errorf("expandPath failed to correctly resolve the symlinked directory.\nGot:  %s\nWant: %s", gotPath, expectedPath)
 	}
 }

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -42,19 +42,15 @@ func TestIsDirFileNot(t *testing.T) {
 }
 
 func TestExpandPathWithRelPath(t *testing.T) {
-	tmp := path.Join("_testdata", "tmp")
-	err := os.Mkdir(tmp, 0750)
-	defer os.Remove(tmp)
-	if err != nil {
-		t.Fatalf("Error creating temp directory for testing: %v", err)
-	}
+	relPath := path.Join("_testdata", "toml", ".air.toml")
 
-	expandedPath, _ := expandPath("_testdata/tmp")
 	wd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("Error getting cwd: %v", err)
 	}
-	expected := path.Join(wd, tmp)
+
+	expandedPath, _ := expandPath(relPath)
+	expected := path.Join(wd, relPath)
 	if expandedPath != expected {
 		t.Errorf("expected %s got %s", expected, expandedPath)
 	}

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -37,6 +38,25 @@ func TestIsDirFileNot(t *testing.T) {
 	result := isDir("main.go")
 	if result != false {
 		t.Errorf("expected '%t' but got '%t'", true, result)
+	}
+}
+
+func TestExpandPathWithRelPath(t *testing.T) {
+	tmp := path.Join("_testdata", "tmp")
+	_, err := os.Create(tmp)
+	defer os.Remove(tmp)
+	if err != nil {
+		t.Fatalf("Error creating temp directory for testing: %v", err)
+	}
+
+	expandedPath, _ := expandPath("_testdata/tmp")
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Error getting cwd: %v", err)
+	}
+	expected := path.Join(wd, tmp)
+	if expandedPath != expected {
+		t.Errorf("expected %s got %s", expected, expandedPath)
 	}
 }
 

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -42,7 +41,7 @@ func TestIsDirFileNot(t *testing.T) {
 }
 
 func TestExpandPathWithRelPath(t *testing.T) {
-	tmp := path.Join("_testdata", "tmp")
+	tmp := filepath.Join("_testdata", "tmp")
 	_, err := os.Create(tmp)
 	defer os.Remove(tmp)
 	if err != nil {
@@ -54,7 +53,11 @@ func TestExpandPathWithRelPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error getting cwd: %v", err)
 	}
-	expected := path.Join(wd, tmp)
+	expected := filepath.Join(wd, tmp)
+	// expandPath resolves symlinks, so resolve expected too
+	if resolved, err := filepath.EvalSymlinks(expected); err == nil {
+		expected = resolved
+	}
 	if expandedPath != expected {
 		t.Errorf("expected %s got %s", expected, expandedPath)
 	}
@@ -69,15 +72,38 @@ func TestExpandPathWithDot(t *testing.T) {
 }
 
 func TestExpandPathWithHomePath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("HOME-based tilde expansion is not reliable on Windows")
+	}
 	path := "~/.conf"
 	result, err := expandPath(path)
 	if err != nil {
 		t.Errorf("expandPath returned an error: %v", err)
 	}
 	home := os.Getenv("HOME")
-	want := home + path[1:]
+	want := filepath.Join(home, path[1:])
 	if result != want {
 		t.Errorf("expected '%s' but got '%s'", want, result)
+	}
+}
+
+func TestExpandPathSymlinkError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("ENOTDIR behavior differs on Windows")
+	}
+	// Create a regular file, then try to expand a path *inside* it.
+	// filepath.EvalSymlinks will return ENOTDIR (not ErrNotExist), triggering
+	// the "unexpected error" branch in expandPath.
+	f, err := os.CreateTemp("", "expandpath-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	f.Close()
+	defer os.Remove(f.Name())
+
+	_, err = expandPath(filepath.Join(f.Name(), "subpath"))
+	if err == nil {
+		t.Fatal("expected an error but got nil")
 	}
 }
 


### PR DESCRIPTION
While the follow_symlink option allows for dereferencing symlinked directories in the project, it does not resolve the root directory to a real directory if it is symbolically linked. This becomes an issue if you are accessing a project directory from a symlink, as filepath.Walk ignores symbolic links.

By adding an additional de-referencing step to Config.preprocess(), this PR resolves Config.Root directories that are themselves symbolic links to their target path so that Engine.watching() will correctly walk the root path.

Closes #531