### PR TITLE
Feat: Use host header for proxy

### DIFF
--- a/air_example.toml
+++ b/air_example.toml
@@ -81,3 +81,5 @@ keep_scroll = true
 enabled = true
 proxy_port = 8090
 app_port = 8080
+use_host_header = false
+retries = 10

--- a/runner/config.go
+++ b/runner/config.go
@@ -89,9 +89,11 @@ type cfgScreen struct {
 }
 
 type cfgProxy struct {
-	Enabled   bool `toml:"enabled" usage:"Enable live-reloading on the browser"`
-	ProxyPort int  `toml:"proxy_port" usage:"Port for proxy server"`
-	AppPort   int  `toml:"app_port" usage:"Port for your app"`
+	Enabled       bool `toml:"enabled" usage:"Enable live-reloading on the browser"`
+	ProxyPort     int  `toml:"proxy_port" usage:"Port for proxy server"`
+	AppPort       int  `toml:"app_port" usage:"Port for your app"`
+	UseHostHeader bool `toml:"use_host_header" usage:"Use host header for hostname when forwarding request"`
+	Retries       int  `toml:"retries" usage:"Number of times to retry connection after restart"`
 }
 
 type sliceTransformer struct{}
@@ -250,6 +252,10 @@ func defaultConfig() Config {
 		Screen: cfgScreen{
 			ClearOnRebuild: false,
 			KeepScroll:     true,
+		},
+		Proxy: cfgProxy{
+			UseHostHeader: false,
+			Retries:       10,
 		},
 	}
 }

--- a/runner/proxy.go
+++ b/runner/proxy.go
@@ -82,7 +82,12 @@ func (p *Proxy) injectLiveReload(resp *http.Response) (string, error) {
 func (p *Proxy) proxyHandler(w http.ResponseWriter, r *http.Request) {
 	appURL := r.URL
 	appURL.Scheme = "http"
-	appURL.Host = fmt.Sprintf("localhost:%d", p.config.AppPort)
+	host := r.Host
+	if idx := strings.Index(host, ":"); idx != -1 {
+		// Strip any existing port from the host
+		host = host[:idx]
+	}
+	appURL.Host = fmt.Sprintf("%s:%d", host, p.config.AppPort)
 
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, "proxy handler: bad form", http.StatusInternalServerError)


### PR DESCRIPTION
My app serves multiple subdomains so for local development I access it with sub1.localhost:port for example. Since the proxy has localhost hardcoded you couldn't use live reload with these urls, this new config allows you to use the host header when proxying the request. I've also added a config for number of retries before failing since apps can take longer than a second to build.  