### PR TITLE
754 - Clean up EventSource when the page is closed/reloaded

### DIFF
--- a/runner/proxy.js
+++ b/runner/proxy.js
@@ -1,6 +1,10 @@
 (() => {
     const eventSource = new EventSource("/__air_internal/sse");
 
+    window.addEventListener('beforeunload', function() {
+        eventSource.close();
+    })
+
     eventSource.addEventListener('reload', () => {
         location.reload();
     });


### PR DESCRIPTION
Fixes [issue 754](https://github.com/air-verse/air/issues/754)

This is a very basic fix but it works. 

I did try to implement a more robust handling of the SSE connection on the server side as well (SSE heartbeats, lowering TCP timeouts), but could not get it to work reliably without also risking making the proxy far less transparent.