### PR TITLE
chore: update golangci-lint to 1.64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61
+          version: v1.64
       - name: Install dependency
         run: if [ $(uname) == "Darwin" ]; then brew install gnu-sed ;fi
       - name: Build

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LDFLAGS += -X "main.airVersion=$(AIRVER)"
 LDFLAGS += -X "main.goVersion=$(shell go version | sed -r 's/go version go(.*)\ .*/\1/')"
 
 GO := GO111MODULE=on CGO_ENABLED=0 go
-GOLANGCI_LINT_VERSION = v1.61.0
+GOLANGCI_LINT_VERSION = v1.64.8
 
 .PHONY: init
 init: install-golangci-lint


### PR DESCRIPTION
Once we are on version 1.64 for golangci-lint, we should also be able to update to the latest go version (1.24). Once that is also done, we can migrate golangci-lint from version 1.x to 2.x :smile: 