### PR TITLE
chore: update golangci lint to 2 1 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         id: go
         uses: actions/setup-go@v5
         with:
-          go-version: ^1.23
+          go-version-file: go.mod
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61
+          version: v1.64
       - name: Install dependency
         run: if [ $(uname) == "Darwin" ]; then brew install gnu-sed ;fi
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,9 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64
+          version: v2.1.2
       - name: Install dependency
         run: if [ $(uname) == "Darwin" ]; then brew install gnu-sed ;fi
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ^1.23
+          go-version-file: go.mod
 
       - name: Set GOVERSION
         run: echo "GOVERSION=$(go version | sed -r 's/go version go(.*)\ .*/\1/')" >> $GITHUB_ENV

--- a/.github/workflows/smoke_test_reuse_job.yml
+++ b/.github/workflows/smoke_test_reuse_job.yml
@@ -18,7 +18,7 @@ jobs:
         id: go
         uses: actions/setup-go@v5
         with:
-          go-version: ^1.23
+          go-version-file: go.mod
       - name: Install
         run: make install
       - name: Check rebuild

--- a/.github/workflows/smoke_test_reuse_job_windows.yml
+++ b/.github/workflows/smoke_test_reuse_job_windows.yml
@@ -18,7 +18,7 @@ jobs:
         id: go
         uses: actions/setup-go@v4
         with:
-          go-version: ^1.23
+          go-version-file: go.mod
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,18 +1,17 @@
-run:
-  timeout: 2m
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-    - copyloopvar # detects places where loop variables are copied
-    - errcheck # Errcheck is a program for checking for unchecked errors in go programs.
-    - gci # Gci controls Go package import order and makes it always deterministic
-    - goimports # checks that goimports was run
-    - ineffassign # Detects when assignments to existing variables are not used
-    - misspell # spell checker
-    - revive # configurable linter for Go. Drop-in replacement of golint
-    - staticcheck # go vet on steroids
-    - stylecheck # static analysis, finds bugs and performance issues, offers simplifications, and enforces style rules
-    - testifylint # checks usage of github.com/stretchr/testify
-    - unconvert # Remove unnecessary type conversions
-    - unused # Checks Go code for unused constants, variables, functions and types
+    - copyloopvar
+    - errcheck
+    - ineffassign
+    - misspell
+    - revive
+    - staticcheck
+    - testifylint
+    - unconvert
+    - unused
+formatters:
+  enable:
+    - gci
+    - goimports

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 LABEL maintainer="Rick Yu <cosmtrek@gmail.com>"
 
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/go/pkg/mod go mod download
 
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build make ci && make install
 
-FROM golang:1.23
+FROM golang:1.24
 
 COPY --from=builder /go/bin/air  /go/bin/air
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LDFLAGS += -X "main.airVersion=$(AIRVER)"
 LDFLAGS += -X "main.goVersion=$(shell go version | sed -r 's/go version go(.*)\ .*/\1/')"
 
 GO := GO111MODULE=on CGO_ENABLED=0 go
-GOLANGCI_LINT_VERSION = v1.61.0
+GOLANGCI_LINT_VERSION = v1.64.8
 
 .PHONY: init
 init: install-golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LDFLAGS += -X "main.airVersion=$(AIRVER)"
 LDFLAGS += -X "main.goVersion=$(shell go version | sed -r 's/go version go(.*)\ .*/\1/')"
 
 GO := GO111MODULE=on CGO_ENABLED=0 go
-GOLANGCI_LINT_VERSION = v1.64.8
+GOLANGCI_LINT_VERSION = v2.1.2
 
 .PHONY: init
 init: install-golangci-lint

--- a/README-ja.md
+++ b/README-ja.md
@@ -56,7 +56,7 @@ air --build.cmd "go build -o bin/api cmd/run.go" --build.bin "./bin/api" --build
 
 ### `go install` を使う場合（推奨）
 
-go 1.23以上を使う場合:
+go 1.24以上を使う場合:
 
 ```bash
 go install github.com/air-verse/air@latest
@@ -219,7 +219,7 @@ services:
 
 ```Dockerfile
 # 1.16以上の利用したいバージョンを選択してください
-FROM golang:1.23-alpine
+FROM golang:1.24-alpine
 
 WORKDIR /app
 

--- a/README-zh_cn.md
+++ b/README-zh_cn.md
@@ -42,7 +42,7 @@ air --build.cmd "go build -o bin/api cmd/run.go" --build.bin "./bin/api" --build
 
 ### 使用 `go install` （推荐）
 
-使用 go 1.23 或更高版本:
+使用 go 1.24 或更高版本:
 
 ```shell
 go install github.com/air-verse/air@latest
@@ -205,7 +205,7 @@ services:
 
 ```Dockerfile
 # 选择你想要的版本，>= 1.16
-FROM golang:1.23-alpine
+FROM golang:1.24-alpine
 
 WORKDIR /app
 

--- a/README-zh_tw.md
+++ b/README-zh_tw.md
@@ -42,7 +42,7 @@ air --build.cmd "go build -o bin/api cmd/run.go" --build.bin "./bin/api" --build
 
 ### 使用 `go install` （推薦）
 
-需要使用 go 1.23 或更高版本：
+需要使用 go 1.24 或更高版本：
 
 ```bash
 go install github.com/air-verse/air@latest

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ air --build.cmd "go build -o bin/api cmd/run.go" --build.bin "./bin/api" --build
 
 ### Via `go install` (Recommended)
 
-With go 1.23 or higher:
+With go 1.24 or higher:
 
 ```bash
 go install github.com/air-verse/air@latest
@@ -219,7 +219,7 @@ services:
 
 ```Dockerfile
 # Choose whatever you want, version >= 1.16
-FROM golang:1.23-alpine
+FROM golang:1.24-alpine
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/air-verse/air
 
-go 1.23
+go 1.24
 
 require (
 	dario.cat/mergo v1.0.1

--- a/hack/check.sh
+++ b/hack/check.sh
@@ -20,7 +20,7 @@ fi
 
 echo -e "${green}2. Linting"
 out=$(golangci-lint run)
-if [[ -n "${out}" ]]; then
+if [[ -n "${out}" && "${out}" != "0 issues." ]]; then
     echo "${red}${out}"
     exit_code=1
 fi


### PR DESCRIPTION
Once https://github.com/air-verse/air/pull/763 is merged, we can update to the next major for golangci-lint 