### PR TITLE
feat: allow recursive mkdir

### DIFF
--- a/runner/engine.go
+++ b/runner/engine.go
@@ -109,7 +109,7 @@ func (e *Engine) checkRunEnv() error {
 	p := e.config.tmpPath()
 	if _, err := os.Stat(p); os.IsNotExist(err) {
 		e.runnerLog("mkdir %s", p)
-		if err := os.Mkdir(p, 0o755); err != nil {
+		if err := os.MkdirAll(p, 0o755); err != nil {
 			e.runnerLog("failed to mkdir, error: %s", err.Error())
 			return err
 		}


### PR DESCRIPTION
Without `os.MkdirAll` air couldn't create nested directories.

## Before
`.airflow.toml`
```toml
root = "."
testdata_dir = "testdata"
tmp_dir = "build/debug"

[build]
  args_bin = []
  bin = "./build/debug/proxyserver"
  cmd = "go build -o ./build/debug/proxyserver ./cmd/proxyserver"
  delay = 1000
  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
  exclude_file = []
  exclude_regex = ["_test.go"]
  exclude_unchanged = false
  follow_symlink = false
  full_bin = ""
  include_dir = []
  include_ext = ["go", "tpl", "tmpl", "html"]
  include_file = []
  kill_delay = "0s"
  log = "build-errors.log"
  poll = false
  poll_interval = 0
  post_cmd = []
  pre_cmd = []
  rerun = false
  rerun_delay = 500
  send_interrupt = false
  stop_on_error = false

[color]
  app = ""
  build = "yellow"
  main = "magenta"
  runner = "green"
  watcher = "cyan"

[log]
  main_only = false
  silent = false
  time = false

[misc]
  clean_on_exit = false

[proxy]
  app_port = 0
  enabled = false
  proxy_port = 0

[screen]
  clear_on_rebuild = false
  keep_scroll = true
```

<img width="603" alt="image" src="https://github.com/user-attachments/assets/ef5661e9-4034-4bcd-889b-6ced5e70fac3" />
