### PR TITLE
docs: add `go get -tool` install method in README

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -62,6 +62,16 @@ go 1.23以上を使う場合:
 go install github.com/air-verse/air@latest
 ```
 
+### `go get -tool` を使う場合
+
+go 1.24以上を使う場合:
+
+```bash
+go get -tool github.com/air-verse/air@latest
+
+go tool air -v
+```
+
 ### `install.sh` を使う場合
 
 ```shell

--- a/README-zh_cn.md
+++ b/README-zh_cn.md
@@ -48,6 +48,16 @@ air --build.cmd "go build -o bin/api cmd/run.go" --build.bin "./bin/api" --build
 go install github.com/air-verse/air@latest
 ```
 
+### 使用 `go get -tool`
+
+使用 go 1.24 或更高版本:
+
+```shell
+go get -tool github.com/air-verse/air@latest
+
+go tool air -v
+```
+
 ### 使用 install.sh
 
 ```shell

--- a/README-zh_tw.md
+++ b/README-zh_tw.md
@@ -48,6 +48,16 @@ air --build.cmd "go build -o bin/api cmd/run.go" --build.bin "./bin/api" --build
 go install github.com/air-verse/air@latest
 ```
 
+### 使用 `go get -tool`
+
+需要使用 go 1.24 或更高版本：
+
+```bash
+go get -tool github.com/air-verse/air@latest
+
+go tool air -v
+```
+
 ### 透過 install.sh
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ With go 1.23 or higher:
 go install github.com/air-verse/air@latest
 ```
 
+### Via `go get -tool` (project install)
+
+With go 1.24 or higher:
+
+```bash
+go get -tool github.com/air-verse/air@latest
+
+# then use it like so:
+go tool air -v
+```
+
 ### Via install.sh
 
 ```shell


### PR DESCRIPTION
Since Go 1.24, go tools can be added to the `go.mod` with the new `tool` directive and `go get -tool` command.  
This allows to download the tool automatically like normal dependencies, and to specify a version specific to each project.

- Go 1.24 releases notes about this: https://go.dev/doc/go1.24#go-command
-  `go get -tool` and `go tool` documentation: https://go.dev/doc/modules/managing-dependencies#tools

In my opinion this would be the new recommended way, but without other opinions I kept the `go install` as the recommended one.