### PR TITLE
feat: add Homebrew formula support via GoReleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,3 +16,15 @@ archives:
     format: tar.gz
   - id: binary
     format: binary
+
+brews:
+  - name: air
+    description: "Live reload for Go apps"
+    homepage: "https://github.com/air-verse/air"
+    repository:
+      owner: air-verse
+      name: homebrew-tap
+    install: |
+      bin.install "air"
+    test: |
+      system "#{bin}/air -v"


### PR DESCRIPTION
## Summary
This PR adds Homebrew formula support to Air via GoReleaser configuration, addressing the need for easier installation on macOS systems.

## Problem
As requested in #571, Air currently doesn't have Homebrew formula support, requiring users to install via:
- `go install` (requires Go toolchain)
- `install.sh` script (requires manual execution)
- Other non-standard methods

macOS users expect to be able to install CLI tools via `brew install`, but this wasn't available for Air.

## Solution
Added Homebrew tap configuration to `.goreleaser.yml` that will:

✅ **Automatically publish formula** on each release to `air-verse/homebrew-tap`
✅ **Enable simple installation** via `brew install air-verse/tap/air`
✅ **Include proper testing** to verify installation works
✅ **Follow Homebrew conventions** for binary placement and metadata

### Configuration Added:
```yaml
brews:
  - name: air
    description: "Live reload for Go apps"
    homepage: "https://github.com/air-verse/air"
    repository:
      owner: air-verse
      name: homebrew-tap
    install: |
      bin.install "air"
    test: |
      system "#{bin}/air -v"
```

## How It Works
1. **On Release**: GoReleaser will automatically create/update the Homebrew formula
2. **Repository**: Formula will be published to `air-verse/homebrew-tap` 
3. **Installation**: Users can install with `brew install air-verse/tap/air`
4. **Updates**: `brew upgrade` will automatically update Air to latest versions

## Benefits
- ✅ **Easier Installation**: Standard `brew install` command
- ✅ **Automatic Updates**: Integrates with Homebrew update system
- ✅ **No Dependencies**: No need for Go toolchain or manual scripts
- ✅ **Version Management**: Easy to install specific versions or upgrade
- ✅ **macOS Integration**: Follows macOS package management standards

## Requirements
- Air maintainers will need to create `air-verse/homebrew-tap` repository
- GoReleaser will need appropriate permissions to push to the tap repository
- Formula will be automatically maintained on each release

## Testing
- [x] Configuration follows GoReleaser Homebrew best practices
- [x] Formula includes proper test command (`air -v`)
- [x] Installation command places binary in correct location
- [x] Metadata (name, description, homepage) is accurate

## Impact
This addresses a frequently requested feature and makes Air more accessible to the macOS development community by following standard package management practices.

Fixes #571

🤖 Generated with [Claude Code](https://claude.ai/code)