### PR TITLE
fix: update smoke test go.mod to use Go 1.24

### DIFF
--- a/smoke_test/check_rebuild/go.mod
+++ b/smoke_test/check_rebuild/go.mod
@@ -1,3 +1,3 @@
 module air.sample.com
 
-go 1.17
+go 1.24


### PR DESCRIPTION
## Summary
- Update Go version in `smoke_test/check_rebuild/go.mod` from 1.17 to 1.24
- This fixes CI failures in the Smoke test workflow on master branch

## Root Cause
PR #771 updated the main project to Go 1.24 but missed updating the smoke test's go.mod file, causing version mismatch issues in CI.

## Changes
- `smoke_test/check_rebuild/go.mod`: Go version updated from 1.17 to 1.24

## Test Plan
- [x] Verify the smoke test go.mod file is updated
- [ ] Confirm CI passes after this change

🤖 Generated with [Claude Code](https://claude.ai/code)