### PR TITLE
Add configuration to keep the last successfully built binary when exiting with stop_on_error set

### DIFF
--- a/air_example.toml
+++ b/air_example.toml
@@ -44,6 +44,8 @@ poll_interval = 500 # ms
 delay = 0 # ms
 # Stop running old binary when build errors occur.
 stop_on_error = true
+# Keep the last successfully built binary when exiting. Only has effect when stop_on_error is true.
+keep_built_binary = false
 # Send Interrupt signal before killing process (windows does not support this feature)
 send_interrupt = false
 # Delay after sending Interrupt signal

--- a/runner/config.go
+++ b/runner/config.go
@@ -54,6 +54,7 @@ type cfgBuild struct {
 	PollInterval     int           `toml:"poll_interval" usage:"Poll interval (defaults to the minimum interval of 500ms)"`
 	Delay            int           `toml:"delay" usage:"It's not necessary to trigger build each time file changes if it's too frequent"`
 	StopOnError      bool          `toml:"stop_on_error" usage:"Stop running old binary when build errors occur"`
+	KeepBuiltBinary  bool          `toml:"keep_built_binary" usage:"Keep the last successfully built binary when exiting. Only has effect when stop_on_error is true."`
 	SendInterrupt    bool          `toml:"send_interrupt" usage:"Send Interrupt signal before killing process (windows does not support this feature)"`
 	KillDelay        time.Duration `toml:"kill_delay" usage:"Delay after sending Interrupt signal"`
 	Rerun            bool          `toml:"rerun" usage:"Rerun binary or not"`

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -559,7 +559,7 @@ func (e *Engine) runBin() error {
 				e.mainDebug("cmd killed, pid: %d", pid)
 			}
 
-			if e.config.Build.StopOnError {
+			if e.config.Build.StopOnError && !e.config.Build.KeepBuiltBinary {
 				cmdBinPath := cmdPath(e.config.rel(e.config.binPath()))
 				if _, err = os.Stat(cmdBinPath); os.IsNotExist(err) {
 					return


### PR DESCRIPTION
When the config `stop_on_error` is set to `true`, the built binary in `bin` gets deleted after stopping `air`.
  
However, it can be useful to to keep the binary around when starting a new session of `air` to not have to recompile it, where we'd like to stop `air` with build errors (`stop_on_error=true`) but keep the latest built binary.  
  
But because `stop_on_error=false` basically requires that the binary exists in order to work, this new config `keep_built_binary` is supplementary and only has effect if `stop_on_error=true`.  
  
The new config is set to `false` by default to not create any breaking changes.
  
Happy to discuss the approach, naming and so on, but hopefully the idea behind is clear.