### PR TITLE
WIP Add manual watch mode for restart control

### DIFF
--- a/air_example.toml
+++ b/air_example.toml
@@ -56,6 +56,9 @@ kill_delay = 500 # nanosecond
 rerun = false
 # Delay after each execution
 rerun_delay = 500
+# Watch mode: "auto" (default) restarts on file changes, "manual" only restarts on 'r' key press.
+# Use "manual" mode when your app has slow startup (e.g., database connections).
+watch_mode = "auto"
 
 [log]
 # Show log time

--- a/runner/config.go
+++ b/runner/config.go
@@ -104,6 +104,7 @@ type cfgBuild struct {
 	KillDelay        time.Duration `toml:"kill_delay" usage:"Delay after sending Interrupt signal"`
 	Rerun            bool          `toml:"rerun" usage:"Rerun binary or not"`
 	RerunDelay       int           `toml:"rerun_delay" usage:"Delay after each execution"`
+	WatchMode        string        `toml:"watch_mode" usage:"Watch mode: auto (default) or manual"`
 	regexCompiled    []*regexp.Regexp
 	includeDirAbs    []string
 	extraIncludeDirs []string
@@ -293,6 +294,7 @@ func defaultConfig() Config {
 		Delay:        1000,
 		Rerun:        false,
 		RerunDelay:   500,
+		WatchMode:    "auto",
 	}
 	if runtime.GOOS == PlatformWindows {
 		build.Bin = `tmp\main.exe`

--- a/runner/config_test.go
+++ b/runner/config_test.go
@@ -331,3 +331,60 @@ cmd = "go build -o ./tmp/main ."
 		t.Fatalf("missing bin deprecation warning in output: %q", output)
 	}
 }
+func TestWatchModeConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		toml     string
+		expected string
+	}{
+		{
+			name:     "default is auto",
+			toml:     ``,
+			expected: "auto",
+		},
+		{
+			name: "explicit auto mode",
+			toml: `[build]
+watch_mode = "auto"`,
+			expected: "auto",
+		},
+		{
+			name: "manual mode",
+			toml: `[build]
+watch_mode = "manual"`,
+			expected: "manual",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			configPath := filepath.Join(tmpDir, ".air.toml")
+
+			if tt.toml != "" {
+				if err := os.WriteFile(configPath, []byte(tt.toml), 0644); err != nil {
+					t.Fatalf("failed to write config file: %v", err)
+				}
+			}
+
+			var cfg *Config
+			var err error
+			if tt.toml == "" {
+				// Test default config
+				defaultCfg := defaultConfig()
+				cfg = &defaultCfg
+			} else {
+				cfg, err = InitConfig(configPath, nil)
+				if err != nil {
+					t.Fatalf("InitConfig failed: %v", err)
+				}
+			}
+
+			if cfg.Build.WatchMode != tt.expected {
+				t.Errorf("WatchMode = %q, want %q", cfg.Build.WatchMode, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
close https://github.com/air-verse/air/issues/804 
Add watch_mode configuration option ('auto' or 'manual') to allow users to control when Air restarts their application. In manual mode, the app only restarts when the user presses 'r', ignoring file changes. This is useful for apps with slow startup times (e.g., database connections).

Changes:
- Add watch_mode field to build config (default: 'auto')
- Add keyboard listener in main.go to detect 'r' key press
- Add manualRestartCh channel to Engine for triggering restarts
- Ignore file change events when in manual mode
- Add tests for watch_mode configuration
- Update air_example.toml with watch_mode documentation