### PR TITLE
fix: restore stdout/stderr inheritance for TTY detection

### DIFF
--- a/runner/util_linux.go
+++ b/runner/util_linux.go
@@ -71,6 +71,9 @@ func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, 
 		return nil, nil, nil, err
 	}
 
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+
 	err = c.Start()
 	if err != nil {
 		return nil, nil, nil, err

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -865,6 +865,28 @@ func Test_killCmd_SendInterrupt_SlowGracefulExit(t *testing.T) {
 		elapsed, 1.0-elapsed.Seconds())
 }
 
+// Regression test for https://github.com/air-verse/air/issues/894
+// Child process must inherit stdout/stderr for TTY detection (isatty).
+func TestStartCmdInheritsStdoutStderr(t *testing.T) {
+	t.Parallel()
+	chdir(t, "_testdata")
+
+	e := Engine{
+		config: &Config{
+			Build: cfgBuild{},
+		},
+	}
+
+	cmd, _, _, err := e.startCmd("echo ok")
+	require.NoError(t, err)
+	_ = cmd.Wait()
+
+	assert.Equal(t, os.Stdout, cmd.Stdout,
+		"child process Stdout should be os.Stdout to preserve TTY detection")
+	assert.Equal(t, os.Stderr, cmd.Stderr,
+		"child process Stderr should be os.Stderr to preserve TTY detection")
+}
+
 func TestIsDangerousRoot(t *testing.T) {
 	t.Parallel()
 

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -866,25 +867,50 @@ func Test_killCmd_SendInterrupt_SlowGracefulExit(t *testing.T) {
 }
 
 // Regression test for https://github.com/air-verse/air/issues/894
-// Child process must inherit stdout/stderr for TTY detection (isatty).
-func TestStartCmdInheritsStdoutStderr(t *testing.T) {
-	t.Parallel()
+// Child process must inherit stdout/stderr so ANSI color codes pass through
+// and TTY detection (isatty) works correctly.
+func TestStartCmdPreservesColorOutput(t *testing.T) {
 	chdir(t, "_testdata")
 
-	e := Engine{
-		config: &Config{
-			Build: cfgBuild{},
-		},
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	captureOutR, captureOutW, err := os.Pipe()
+	require.NoError(t, err)
+	captureErrR, captureErrW, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = captureOutW
+	os.Stderr = captureErrW
+	t.Cleanup(func() {
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+		captureOutR.Close()
+		captureOutW.Close()
+		captureErrR.Close()
+		captureErrW.Close()
+	})
+
+	e := Engine{config: &Config{Build: cfgBuild{}}}
+
+	var colorCmd string
+	if runtime.GOOS == "windows" {
+		colorCmd = `$e=[char]0x1b; [Console]::Out.Write("${e}[31mhello${e}[0m"); [Console]::Error.Write("${e}[32mworld${e}[0m")`
+	} else {
+		colorCmd = `printf '\033[31mhello\033[0m'; printf '\033[32mworld\033[0m' >&2`
 	}
 
-	cmd, _, _, err := e.startCmd("echo ok")
+	cmd, _, _, err := e.startCmd(colorCmd)
 	require.NoError(t, err)
 	_ = cmd.Wait()
 
-	assert.Equal(t, os.Stdout, cmd.Stdout,
-		"child process Stdout should be os.Stdout to preserve TTY detection")
-	assert.Equal(t, os.Stderr, cmd.Stderr,
-		"child process Stderr should be os.Stderr to preserve TTY detection")
+	captureOutW.Close()
+	captureErrW.Close()
+	stdoutData, _ := io.ReadAll(captureOutR)
+	stderrData, _ := io.ReadAll(captureErrR)
+
+	assert.Contains(t, string(stdoutData), "\033[31m",
+		"child process stdout should preserve ANSI escape codes for color output")
+	assert.Contains(t, string(stderrData), "\033[32m",
+		"child process stderr should preserve ANSI escape codes for color output")
 }
 
 func TestIsDangerousRoot(t *testing.T) {

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -889,7 +889,8 @@ func TestStartCmdPreservesColorOutput(t *testing.T) {
 		captureErrW.Close()
 	})
 
-	e := Engine{config: &Config{Build: cfgBuild{}}}
+	cfg := &Config{Build: cfgBuild{}}
+	e := Engine{config: cfg, logger: newLogger(cfg)}
 
 	var colorCmd string
 	if runtime.GOOS == "windows" {

--- a/runner/util_unix.go
+++ b/runner/util_unix.go
@@ -4,6 +4,7 @@ package runner
 
 import (
 	"io"
+	"os"
 	"os/exec"
 	"syscall"
 	"time"
@@ -68,6 +69,9 @@ func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, 
 	if err != nil {
 		return nil, nil, nil, err
 	}
+
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
 
 	err = c.Start()
 	if err != nil {

--- a/runner/util_windows.go
+++ b/runner/util_windows.go
@@ -4,6 +4,7 @@ package runner
 
 import (
 	"io"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -40,8 +41,6 @@ func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 }
 
 func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
-	var err error
-
 	if !strings.Contains(cmd, ".exe") {
 		e.runnerLog("CMD will not recognize non .exe file for execution, path: %s", cmd)
 	}
@@ -58,6 +57,9 @@ func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, 
 	if err != nil {
 		return nil, nil, nil, err
 	}
+
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
 
 	err = c.Start()
 	if err != nil {

--- a/runner/util_windows.go
+++ b/runner/util_windows.go
@@ -41,6 +41,8 @@ func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 }
 
 func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
+	var err error
+
 	if !strings.Contains(cmd, ".exe") {
 		e.runnerLog("CMD will not recognize non .exe file for execution, path: %s", cmd)
 	}


### PR DESCRIPTION
Restores `c.Stdout = os.Stdout` / `c.Stderr = os.Stderr` removed in 0d9e5e1. These were not dead code — setting `c.Stdout` after `StdoutPipe()` overrides the pipe, so the child inherits the real terminal fd. Without this, `isatty()` returns false and applications checking it lose color output.

Fixes #894

---
This PR was written with the help of Claude Opus 4.6