### PR TITLE
docs: add Scoop install instructions

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -105,6 +105,12 @@ curl -sSfL https://goblin.run/github.com/air-verse/air | PREFIX=/tmp sh
 mise use -g air
 ```
 
+### [Scoop](https://scoop.sh) を使う場合
+
+```shell
+scoop install air
+```
+
 ### Docker/Podman
 
 [cosmtrek/air](https://hub.docker.com/r/cosmtrek/air) という Docker イメージをプルしてください。

--- a/README-zh_cn.md
+++ b/README-zh_cn.md
@@ -91,6 +91,12 @@ curl -sSfL https://goblin.run/github.com/cosmtrek/air | PREFIX=/tmp sh
 mise use -g air
 ```
 
+### 使用 [Scoop](https://scoop.sh)
+
+```shell
+scoop install air
+```
+
 ### Docker/Podman
 
 请拉取这个 Docker 镜像 [cosmtrek/air](https://hub.docker.com/r/cosmtrek/air).

--- a/README-zh_tw.md
+++ b/README-zh_tw.md
@@ -91,6 +91,12 @@ curl -sSfL https://goblin.run/github.com/air-verse/air | PREFIX=/tmp sh
 mise use -g air
 ```
 
+### 透過 [Scoop](https://scoop.sh)
+
+```shell
+scoop install air
+```
+
 ### 透過 `go install`
 
 使用 go 1.25 或更高版本:

--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ curl -sSfL https://goblin.run/github.com/air-verse/air | PREFIX=/tmp sh
 brew install go-air
 ```
 
+### Via [Scoop](https://scoop.sh)
+
+```shell
+scoop install air
+```
+
 ### Using software package manager [mise](https://github.com/jdx/mise)
 
 ```shell


### PR DESCRIPTION
## Summary
Add Scoop installation instructions to the README docs.

## Changes
- Add `scoop install air` to the English README.
- Add the same Scoop install command to Simplified Chinese, Traditional Chinese, and Japanese READMEs.

## Testing
Documentation-only change. No tests run.

## Screenshots
N/A

## Checklist
- [ ] Tests pass
- [x] Documentation updated
- [x] No breaking changes