### PR TITLE
Extend stale workflow timeout

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/stale@v10
         with:
-          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
-          stale-pr-message: "This PR is stale because it has had no activity for 30 days..."
-          days-before-stale: 30
+          stale-issue-message: 'This issue is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-pr-message: "This PR is stale because it has had no activity for 180 days..."
+          days-before-stale: 180
           days-before-close: 5


### PR DESCRIPTION
## Summary
Extend the stale workflow timeout from 30 days to 180 days for issues and pull requests.

## Changes
- Update stale issue message to mention 180 days of inactivity.
- Update stale PR message to mention 180 days of inactivity.
- Change `days-before-stale` from 30 to 180.

## Testing
Workflow-only change. No local tests run.

## Screenshots
N/A

## Checklist
- [ ] Tests pass
- [ ] Documentation updated
- [x] No breaking changes