### PR TITLE
Increase stale workflow operation limit

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,3 +18,4 @@ jobs:
           stale-pr-message: "This PR is stale because it has had no activity for 180 days..."
           days-before-stale: 180
           days-before-close: 5
+          operations-per-run: 100


### PR DESCRIPTION
## Summary
Increase the stale workflow operation limit so the action can process more stale issues and PRs in each run.

## Changes
- Add `operations-per-run: 100` to `.github/workflows/stale.yml`.

## Testing
Not run. This change only updates a GitHub Actions workflow setting.

## Screenshots
N/A

## Checklist
- [ ] Tests pass
- [ ] Documentation updated
- [ ] No breaking changes