### PR TITLE
Add configurable color output mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -136,7 +136,7 @@ func main() {
 	case "auto", "":
 		// do nothing
 	default:
-		log.Fatal("unsupported color mode: use always, never, auto")
+		log.Fatalf("unsupported color mode: %s. Expected always, auto, or never", colorMode)
 	}
 
 	if showVersion {

--- a/runner/config.go
+++ b/runner/config.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"dario.cat/mergo"
+	"github.com/fatih/color"
 	"github.com/pelletier/go-toml"
 )
 
@@ -163,6 +164,7 @@ type cfgColor struct {
 	Watcher string `toml:"watcher" usage:"Customize watcher part's color"`
 	Build   string `toml:"build" usage:"Customize build part's color"`
 	Runner  string `toml:"runner" usage:"Customize runner part's color"`
+	Force   bool   `toml:"force" usage:"Force colorized output"`
 	App     string `toml:"app"`
 }
 
@@ -632,6 +634,11 @@ func (c *Config) preprocess(args map[string]TomlInfo) error {
 	// Fix windows CMD processor
 	// CMD will not recognize relative path like ./tmp/server
 	c.Build.Bin, err = filepath.Abs(c.Build.Bin)
+
+	if c.Color.Force == true {
+		// Force colorful output, see https://github.com/fatih/color#disableenable-color
+		color.NoColor = false
+	}
 
 	return err
 }

--- a/runner/config.go
+++ b/runner/config.go
@@ -164,7 +164,7 @@ type cfgColor struct {
 	Watcher string `toml:"watcher" usage:"Customize watcher part's color"`
 	Build   string `toml:"build" usage:"Customize build part's color"`
 	Runner  string `toml:"runner" usage:"Customize runner part's color"`
-	Force   bool   `toml:"force" usage:"Force colorized output"`
+	Mode    string `toml:"mode" usage:"Colorized output mode, one of always, auto, or never. Defaults to auto"`
 	App     string `toml:"app"`
 }
 
@@ -635,9 +635,16 @@ func (c *Config) preprocess(args map[string]TomlInfo) error {
 	// CMD will not recognize relative path like ./tmp/server
 	c.Build.Bin, err = filepath.Abs(c.Build.Bin)
 
-	if c.Color.Force == true {
-		// Force colorful output, see https://github.com/fatih/color#disableenable-color
+	// Set colorful output, see https://github.com/fatih/color#disableenable-color
+	switch c.Color.Mode {
+	case "always":
 		color.NoColor = false
+	case "never":
+		color.NoColor = true
+	case "auto", "":
+		break
+	default:
+		return fmt.Errorf("unsupported value for color mode: %s. Expected always, auto, or never", c.Color.Mode)
 	}
 
 	return err

--- a/runner/config.go
+++ b/runner/config.go
@@ -627,13 +627,6 @@ func (c *Config) preprocess(args map[string]TomlInfo) error {
 	}
 
 	c.Build.ExcludeDir = ed
-	if len(c.Build.FullBin) > 0 {
-		c.Build.Bin = c.Build.FullBin
-		return err
-	}
-	// Fix windows CMD processor
-	// CMD will not recognize relative path like ./tmp/server
-	c.Build.Bin, err = filepath.Abs(c.Build.Bin)
 
 	// Set colorful output, see https://github.com/fatih/color#disableenable-color
 	switch c.Color.Mode {
@@ -646,6 +639,14 @@ func (c *Config) preprocess(args map[string]TomlInfo) error {
 	default:
 		return fmt.Errorf("unsupported value for color mode: %s. Expected always, auto, or never", c.Color.Mode)
 	}
+
+	if len(c.Build.FullBin) > 0 {
+		c.Build.Bin = c.Build.FullBin
+		return err
+	}
+	// Fix windows CMD processor
+	// CMD will not recognize relative path like ./tmp/server
+	c.Build.Bin, err = filepath.Abs(c.Build.Bin)
 
 	return err
 }

--- a/runner/config.go
+++ b/runner/config.go
@@ -637,7 +637,7 @@ func (c *Config) preprocess(args map[string]TomlInfo) error {
 	case "auto", "":
 		break
 	default:
-		return fmt.Errorf("unsupported value for color mode: %s. Expected always, auto, or never", c.Color.Mode)
+		return fmt.Errorf("unsupported color mode: %s. Expected always, auto, or never", c.Color.Mode)
 	}
 
 	if len(c.Build.FullBin) > 0 {

--- a/runner/config_test.go
+++ b/runner/config_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/fatih/color"
 )
 
 const (
@@ -1118,4 +1120,64 @@ cmd = "go build -o ./tmp/main ."
 			t.Fatalf("unexpected root directory protection warning in output: %q", output)
 		}
 	})
+}
+
+func TestColorMode(t *testing.T) {
+	// Save and restore the global NoColor state so tests don't bleed into each other.
+	original := color.NoColor
+	t.Cleanup(func() { color.NoColor = original })
+
+	cases := []struct {
+		name        string
+		mode        string
+		wantNoColor bool
+		wantErr     bool
+	}{
+		{name: "always enables color", mode: "always", wantNoColor: false},
+		{name: "never disables color", mode: "never", wantNoColor: true},
+		{name: "auto leaves default", mode: "auto", wantNoColor: original},
+		{name: "empty leaves default", mode: "", wantNoColor: original},
+		{name: "invalid returns error", mode: "rainbow", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			color.NoColor = original
+			cfg := defaultConfig()
+			cfg.Color.Mode = tc.mode
+			err := cfg.preprocess(nil)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), "unsupported color mode") {
+					t.Fatalf("unexpected error message: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if color.NoColor != tc.wantNoColor {
+				t.Fatalf("color.NoColor = %v, want %v", color.NoColor, tc.wantNoColor)
+			}
+		})
+	}
+}
+
+func TestColorModeWithFullBin(t *testing.T) {
+	// Regression: color mode must be applied even when build.full_bin is set,
+	// because preprocess returns early after FullBin is processed.
+	original := color.NoColor
+	t.Cleanup(func() { color.NoColor = original })
+
+	cfg := defaultConfig()
+	cfg.Build.FullBin = "./tmp/main"
+	cfg.Color.Mode = "never"
+	if err := cfg.preprocess(nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !color.NoColor {
+		t.Fatal("color.NoColor should be true when mode=never and full_bin is set")
+	}
 }


### PR DESCRIPTION
## Summary
Adds a color output mode setting so users can choose always, auto, or never for colored output.

## Changes
- Add `color.mode` to the config schema.
- Apply `always`, `auto`, and `never` modes during config preprocessing.
- Return a clear error for unsupported color mode values.

## Testing
`go test ./...`

## Screenshots
N/A

## Checklist
- [x] Tests pass
- [ ] Documentation updated
- [x] No breaking changes