### PR TITLE
fix: rewatch files after atomic saves

### DIFF
--- a/runner/engine.go
+++ b/runner/engine.go
@@ -322,8 +322,10 @@ func (e *Engine) watchPath(path string) error {
 				}
 				// Rewatch the file if the editor is using atomic saving.
 				if renameOrRemoveEvent(ev) {
-					if err := e.watcher.Add(ev.Name); err != nil {
-						e.watcherLog("error rewatching file: %v", err)
+					if e.checkIncludeFile(path) {
+						if err := e.watcher.Add(ev.Name); err != nil {
+							e.watcherLog("error rewatching file: %v", err)
+						}
 					}
 				}
 				e.watcherDebug("%s has changed", e.config.rel(ev.Name))

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -322,7 +322,7 @@ func (e *Engine) watchPath(path string) error {
 				}
 				// Rewatch the file if the editor is using atomic saving.
 				if renameOrRemoveEvent(ev) {
-					if e.checkIncludeFile(path) {
+					if e.checkIncludeFile(ev.Name) {
 						if err := e.watcher.Add(ev.Name); err != nil {
 							e.watcherLog("error rewatching file: %v", err)
 						}

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -320,6 +320,12 @@ func (e *Engine) watchPath(path string) error {
 				if !e.isIncludeExt(ev.Name) && !e.checkIncludeFile(ev.Name) {
 					break
 				}
+				// Rewatch the file if the editor is using atomic saving.
+				if renameOrRemoveEvent(ev) {
+					if err := e.watcher.Add(ev.Name); err != nil {
+						e.watcherLog("error rewatching file: %v", err)
+					}
+				}
 				e.watcherDebug("%s has changed", e.config.rel(ev.Name))
 				e.eventCh <- ev.Name
 			case err := <-e.watcher.Errors():

--- a/runner/util.go
+++ b/runner/util.go
@@ -303,11 +303,17 @@ func isDir(path string) bool {
 func validEvent(ev fsnotify.Event) bool {
 	return ev.Op&fsnotify.Create == fsnotify.Create ||
 		ev.Op&fsnotify.Write == fsnotify.Write ||
-		ev.Op&fsnotify.Remove == fsnotify.Remove
+		ev.Op&fsnotify.Remove == fsnotify.Remove ||
+		ev.Op&fsnotify.Rename == fsnotify.Rename
 }
 
 func removeEvent(ev fsnotify.Event) bool {
 	return ev.Op&fsnotify.Remove == fsnotify.Remove
+}
+
+func renameOrRemoveEvent(ev fsnotify.Event) bool {
+	return ev.Op&fsnotify.Remove == fsnotify.Remove ||
+		ev.Op&fsnotify.Rename == fsnotify.Rename
 }
 
 func cmdPath(path string) string {

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -169,10 +169,14 @@ func TestValidAndRemoveEvent(t *testing.T) {
 	assert.True(t, validEvent(fsnotify.Event{Op: fsnotify.Create}))
 	assert.True(t, validEvent(fsnotify.Event{Op: fsnotify.Write}))
 	assert.True(t, validEvent(fsnotify.Event{Op: fsnotify.Remove}))
-	assert.False(t, validEvent(fsnotify.Event{Op: fsnotify.Rename}))
+	assert.True(t, validEvent(fsnotify.Event{Op: fsnotify.Rename}))
 
 	assert.True(t, removeEvent(fsnotify.Event{Op: fsnotify.Remove}))
 	assert.False(t, removeEvent(fsnotify.Event{Op: fsnotify.Write}))
+
+	assert.True(t, renameOrRemoveEvent(fsnotify.Event{Op: fsnotify.Remove}))
+	assert.True(t, renameOrRemoveEvent(fsnotify.Event{Op: fsnotify.Rename}))
+	assert.False(t, renameOrRemoveEvent(fsnotify.Event{Op: fsnotify.Write}))
 }
 
 func TestCmdPath(t *testing.T) {


### PR DESCRIPTION
## Summary
Fix watcher handling for editors that save files atomically by rename/remove. Air now treats rename events as valid and re-adds watched files after rename/remove events.
close https://github.com/air-verse/air/issues/496

## Changes
- Treat fsnotify rename events as valid file changes.
- Re-add watched files after rename or remove events, with error logging.
- Update event helper tests for rename and remove handling.

## Testing
- go test ./...
- make check

## Screenshots
N/A

## Checklist
- [x] Tests pass
- [ ] Documentation updated
- [x] No breaking changes