### PR TITLE
fix: honor --build.bin when no config file exists

### DIFF
--- a/runner/config.go
+++ b/runner/config.go
@@ -202,7 +202,7 @@ func (t sliceTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Va
 
 // InitConfig initializes the configuration.
 func InitConfig(path string, cmdArgs map[string]TomlInfo) (*Config, error) {
-	ret, err := initConfigWithoutPreprocess(path)
+	ret, fromFile, err := initConfigWithoutPreprocess(path)
 	if err != nil {
 		return nil, err
 	}
@@ -211,14 +211,14 @@ func InitConfig(path string, cmdArgs map[string]TomlInfo) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	warnDeprecatedBin(ret)
+	warnDeprecatedBin(ret, fromFile || hasChangedArg(cmdArgs, "build.bin"))
 
 	return ret, nil
 }
 
 // InitConfigForDisplay initializes config without preprocess side effects.
 func InitConfigForDisplay(path string, cmdArgs map[string]TomlInfo) (*Config, error) {
-	ret, err := initConfigWithoutPreprocess(path)
+	ret, _, err := initConfigWithoutPreprocess(path)
 	if err != nil {
 		return nil, err
 	}
@@ -228,22 +228,24 @@ func InitConfigForDisplay(path string, cmdArgs map[string]TomlInfo) (*Config, er
 	return ret, nil
 }
 
-func initConfigWithoutPreprocess(path string) (*Config, error) {
+func initConfigWithoutPreprocess(path string) (*Config, bool, error) {
 	var (
-		cfg *Config
-		err error
+		cfg      *Config
+		fromFile bool
+		err      error
 	)
 
 	if path == "" {
-		cfg, err = defaultPathConfig()
+		cfg, fromFile, err = defaultPathConfig()
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 	} else {
 		cfg, err = readConfigOrDefault(path)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
+		fromFile = true
 	}
 	config := defaultConfig()
 	// get addr
@@ -256,13 +258,13 @@ func initConfigWithoutPreprocess(path string) (*Config, error) {
 		config.Overwrite = true
 	})
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	if err = applyPlatformOverrides(ret); err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return ret, nil
+	return ret, fromFile, nil
 }
 
 func writeDefaultConfig() (string, error) {
@@ -299,23 +301,24 @@ func writeDefaultConfig() (string, error) {
 	return dftTOML, nil
 }
 
-func defaultPathConfig() (*Config, error) {
+// defaultPathConfig loads `.air.toml` or `.config/air.toml` when present.
+// The bool is true when a config file was loaded, false when defaults are returned.
+func defaultPathConfig() (*Config, bool, error) {
 	// when path is blank, first find `.air.toml` in `air_wd` and current working directory or .config/air.toml, if not found, use defaults
 	for _, name := range []string{dftTOML, cfgTOML} {
 		cfg, err := readConfByName(name)
 		if err == nil {
-			return cfg, nil
+			return cfg, true, nil
 		}
 		// If the config file exists but failed to parse, report the error
 		// Only use defaults if no config file exists
 		if !os.IsNotExist(err) {
-			return nil, fmt.Errorf("failed to parse %s: %w", name, err)
+			return nil, false, fmt.Errorf("failed to parse %s: %w", name, err)
 		}
 	}
 
 	dftCfg := defaultConfig()
-	setEntrypointFromBin(&dftCfg)
-	return &dftCfg, nil
+	return &dftCfg, false, nil
 }
 
 func readConfByName(name string) (*Config, error) {
@@ -817,7 +820,7 @@ func (c *Config) withArgs(args map[string]TomlInfo) {
 	for _, value := range args {
 		// Ignore values that match the default configuration.
 		// This ensures user-specified configurations are not overwritten by default values.
-		if value.Value != nil && *value.Value != value.fieldValue {
+		if value.changed() {
 			v := reflect.ValueOf(c)
 			setValue2Struct(v, value.fieldPath, *value.Value)
 		}
@@ -825,15 +828,24 @@ func (c *Config) withArgs(args map[string]TomlInfo) {
 
 }
 
-func warnDeprecatedBin(cfg *Config) {
+// hasChangedArg reports whether the named CLI flag was supplied with a
+// non-default value.
+func hasChangedArg(args map[string]TomlInfo, key string) bool {
+	info, ok := args[key]
+	return ok && info.changed()
+}
+
+// warnDeprecatedBin warns when build.bin is in use without build.entrypoint.
+// binExplicit must be true to warn, so plain `air` with no config or flags
+// stays quiet about a default the user never set.
+func warnDeprecatedBin(cfg *Config, binExplicit bool) {
 	if cfg == nil {
 		return
 	}
-	if cfg.Build.Bin == "" || len(cfg.Build.Entrypoint) > 0 {
+	if !binExplicit {
 		return
 	}
-
-	if cfg.Build.Bin != "" && len(cfg.Build.Entrypoint) > 0 {
+	if cfg.Build.Bin == "" || len(cfg.Build.Entrypoint) > 0 {
 		return
 	}
 

--- a/runner/config_test.go
+++ b/runner/config_test.go
@@ -94,7 +94,7 @@ func TestDefaultPathConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv(airWd, tt.path)
-			c, err := defaultPathConfig()
+			c, _, err := defaultPathConfig()
 			if err != nil {
 				t.Fatalf("Should not be fail: %s.", err)
 			}
@@ -118,7 +118,7 @@ func TestDefaultPathConfigWithInvalidTOML(t *testing.T) {
 	// Test that defaultPathConfig returns an error when .air.toml exists but has parse errors
 	// This is a regression test for issue #678
 	t.Setenv(airWd, "_testdata/invalid_toml")
-	_, err := defaultPathConfig()
+	_, _, err := defaultPathConfig()
 	if err == nil {
 		t.Fatal("expected error when .air.toml has parse errors, but got nil")
 	}
@@ -127,6 +127,22 @@ func TestDefaultPathConfigWithInvalidTOML(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "defined twice") {
 		t.Fatalf("expected error message to contain 'defined twice', got: %s", err.Error())
+	}
+}
+
+func TestDefaultPathConfigDoesNotPrepopulateEntrypoint(t *testing.T) {
+	// A non-empty Entrypoint takes precedence over Bin at runtime, so leaving
+	// it unset is what lets a later --build.bin override actually take effect.
+	t.Setenv(airWd, t.TempDir())
+	c, fromFile, err := defaultPathConfig()
+	if err != nil {
+		t.Fatalf("defaultPathConfig: %v", err)
+	}
+	if fromFile {
+		t.Fatalf("fromFile = true, want false (no TOML in temp dir)")
+	}
+	if len(c.Build.Entrypoint) != 0 {
+		t.Fatalf("Build.Entrypoint = %v, want empty", c.Build.Entrypoint)
 	}
 }
 

--- a/runner/flag_test.go
+++ b/runner/flag_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"flag"
 	"log"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -155,14 +156,45 @@ func TestConfigRuntimeArgs(t *testing.T) {
 				assert.True(t, strings.HasSuffix(conf.Build.Entrypoint.binary(), want), "entrypoint %s does not end with %s", conf.Build.Entrypoint.binary(), want)
 			},
 		},
+		{
+			name: "build.bin alone is honored when no config file exists",
+			args: []string{"--build.bin", "tmp/server"},
+			check: func(t *testing.T, conf *Config) {
+				assert.Empty(t, conf.Build.Entrypoint,
+					"Entrypoint should stay empty so Bin wins in runnerBin/binPath")
+				want := filepath.Join("tmp", "server")
+				assert.True(t, strings.HasSuffix(conf.Build.Bin, want),
+					"Build.Bin = %q, want suffix %q", conf.Build.Bin, want)
+				assert.True(t, strings.HasSuffix(conf.runnerBin(), want),
+					"runnerBin() = %q, want suffix %q", conf.runnerBin(), want)
+				assert.True(t, strings.HasSuffix(conf.binPath(), want),
+					"binPath() = %q, want suffix %q", conf.binPath(), want)
+			},
+		},
+		{
+			name: "build.bin + build.cmd together (issue repro)",
+			args: []string{
+				"--build.cmd", "go build -o ./tmp/server ./main.go",
+				"--build.bin", "tmp/server",
+			},
+			check: func(t *testing.T, conf *Config) {
+				assert.Equal(t, "go build -o ./tmp/server ./main.go", conf.Build.Cmd)
+				want := filepath.Join("tmp", "server")
+				assert.True(t, strings.HasSuffix(conf.runnerBin(), want),
+					"runnerBin() = %q, want suffix %q", conf.runnerBin(), want)
+				assert.True(t, strings.HasSuffix(conf.binPath(), want),
+					"binPath() = %q, want suffix %q", conf.binPath(), want)
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
 			chdir(t, dir)
+			silenceStderr(t)
 			flag := flag.NewFlagSet(t.Name(), flag.ExitOnError)
 			cmdArgs := ParseConfigFlag(flag)
-			_ = flag.Parse(tc.args)
+			require.NoError(t, flag.Parse(tc.args))
 			cfg, err := InitConfig("", cmdArgs)
 			if err != nil {
 				log.Fatal(err)
@@ -171,4 +203,19 @@ func TestConfigRuntimeArgs(t *testing.T) {
 			tc.check(t, cfg)
 		})
 	}
+}
+
+// silenceStderr redirects os.Stderr to the OS null device for the lifetime
+// of the test, hiding warnings (e.g. the build.bin deprecation notice) that
+// would otherwise leak into test output.
+func silenceStderr(t *testing.T) {
+	t.Helper()
+	orig := os.Stderr
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	require.NoError(t, err)
+	os.Stderr = devNull
+	t.Cleanup(func() {
+		os.Stderr = orig
+		_ = devNull.Close()
+	})
 }

--- a/runner/util.go
+++ b/runner/util.go
@@ -390,6 +390,12 @@ type TomlInfo struct {
 	usage      string
 }
 
+// changed reports whether the flag value differs from the built-in default.
+// A flag supplied with its literal default is treated as not changed.
+func (t TomlInfo) changed() bool {
+	return t.Value != nil && *t.Value != t.fieldValue
+}
+
 func setValue2Struct(v reflect.Value, fieldName string, value string) {
 	index := strings.Index(fieldName, ".")
 	if index == -1 && len(fieldName) == 0 {


### PR DESCRIPTION
## Summary

Fixes `--build.bin` being silently ignored when Air runs without a config file.

When no `.air.toml` or `.config/air.toml` exists, Air pre-populated `build.entrypoint` from the default `build.bin` before CLI flags were applied. `--build.bin tmp/server` updated `Build.Bin`, but runtime still preferred the stale default entrypoint and tried to run `./tmp/main`.

## Changes

- Stop pre-populating `Build.Entrypoint` when falling back to built-in defaults.
- Track whether config came from a file so plain `air` does not emit a false `build.bin` deprecation warning.
- Still warn when `build.bin` is explicitly used from TOML or `--build.bin`.
- Add regression tests for no-config `--build.bin`, including the `--build.cmd ... --build.bin ...` repro.

## Semver Note

`--build.bin` is deprecated but still accepted, so users can reasonably expect it to keep working throughout `v1.x`.

If Air removes `--build.bin`, the semver-safe path is to keep it functional with warnings in `v1.x`, then remove or reject it in `v2.0.0`. This PR keeps the deprecated flag usable while it remains accepted.

## Context

This is related to the migration from `build.bin` to `build.entrypoint` in earlier changes such as #826 and #838. This PR does not change that migration path; it only fixes the no-config case where the deprecated flag was accepted but shadowed by the default entrypoint.

## Validation

```sh
go test ./runner -run '^TestDefaultPathConfig|^TestDefaultPathConfigWithInvalidTOML|^TestDefaultPathConfigDoesNotPrepopulateEntrypoint|^TestConfigRuntimeArgs|^TestFlag|^TestConfPreprocess|
^TestEntrypoint|^TestInitConfigWithoutConfigDoesNotWarnDeprecatedBin|^TestWarnDeprecatedBin$' -count=1 -v