### PR TITLE
feat: add build.rules to run commands on change without rebuilding

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,33 @@ entrypoint = ["tmp\\main.exe"]
 
 Running `air init` adds a platform block for the current OS when its defaults differ from the base configuration.
 
+### Watch rules: run a command instead of rebuilding
+
+Sometimes a change should run a command rather than rebuild your app — frontend assets served from disk, `templ`/`sqlc`/`go generate` pipelines, and so on. Declare a `[[build.rules]]` block for each of them:
+
+```toml
+[build]
+cmd = "go build -o ./tmp/main ."
+# the main build ignores the frontend...
+exclude_dir = ["web"]
+
+# ...but this rule watches it and rebuilds the assets on change
+[[build.rules]]
+name = "assets"
+include_dir = ["web"]
+include_ext = ["js", "ts", "css"]
+cmd = "npm run build"
+
+[[build.rules]]
+name = "templ"
+include_ext = ["templ"]
+cmd = "templ generate"
+```
+
+A file matched by a rule runs the rule's `cmd` and never triggers a rebuild, even if it would also match the main build's watch settings. Rule directories are watched even when listed in `exclude_dir`. If a rule's command generates files the main build watches (for example, `templ generate` writing `.go` files), the rebuild follows naturally.
+
+Each rule supports `include_dir`, `include_ext`, `include_file`, `exclude_regex`, and a `delay` (debounce in milliseconds, default 1000). At least one of the `include_*` matchers is required. Rules run their commands to completion; changes arriving meanwhile queue a follow-up run.
+
 ### Docker Compose
 
 ```yaml

--- a/air_example.toml
+++ b/air_example.toml
@@ -63,6 +63,26 @@ rerun = false
 # Delay after each execution
 rerun_delay = 500
 
+# Rules watch files and run a command when they change, without rebuilding
+# and restarting the main binary. Useful for assets, code generation, etc.
+# A file matched by a rule never triggers a rebuild; if the rule's command
+# generates watched files (e.g. .go files), the rebuild follows naturally.
+# [[build.rules]]
+# # Rule name used in logs. Defaults to "rule-<index>".
+# name = "assets"
+# # Command to run when a matched file changes. Required.
+# cmd = "npm run build"
+# # Match files under these directories, even ones listed in exclude_dir.
+# include_dir = ["web"]
+# # Match these filename extensions. Empty matches any extension.
+# include_ext = ["js", "ts", "css"]
+# # Match these files.
+# include_file = []
+# # Exclude specific regular expressions.
+# exclude_regex = []
+# # Debounce delay in milliseconds before running cmd.
+# delay = 1000
+
 # Platform-specific build overrides
 [build.windows]
 cmd = "go build -o ./tmp/main.exe ."

--- a/runner/config.go
+++ b/runner/config.go
@@ -117,6 +117,7 @@ type cfgBuild struct {
 	KillDelay              time.Duration      `toml:"kill_delay" usage:"Delay after sending Interrupt signal"`
 	Rerun                  bool               `toml:"rerun" usage:"Rerun binary or not"`
 	RerunDelay             int                `toml:"rerun_delay" usage:"Delay after each execution"`
+	Rules                  []cfgRule          `toml:"rules"`
 	Windows                *cfgBuildOverrides `toml:"windows,omitempty"`
 	Darwin                 *cfgBuildOverrides `toml:"darwin,omitempty"`
 	Linux                  *cfgBuildOverrides `toml:"linux,omitempty"`
@@ -127,6 +128,63 @@ type cfgBuild struct {
 
 func (c *cfgBuild) RegexCompiled() ([]*regexp.Regexp, error) {
 	return c.regexCompiled, nil
+}
+
+// cfgRule watches a set of files and runs a command when they change,
+// without triggering a rebuild of the main binary.
+type cfgRule struct {
+	Name          string   `toml:"name" usage:"Rule name used in logs"`
+	Cmd           string   `toml:"cmd" usage:"Command to run when a matched file changes"`
+	IncludeDir    []string `toml:"include_dir" usage:"Match files under these directories"`
+	IncludeExt    []string `toml:"include_ext" usage:"Match these filename extensions"`
+	IncludeFile   []string `toml:"include_file" usage:"Match these files"`
+	ExcludeRegex  []string `toml:"exclude_regex" usage:"Exclude specific regular expressions"`
+	Delay         int      `toml:"delay" usage:"Debounce delay in milliseconds before running cmd"`
+	regexCompiled []*regexp.Regexp
+	includeDirAbs []string
+}
+
+func (r *cfgRule) delay() time.Duration {
+	if r.Delay <= 0 {
+		return 1000 * time.Millisecond
+	}
+	return time.Duration(r.Delay) * time.Millisecond
+}
+
+func (c *cfgBuild) normalizeRules(root string) error {
+	for i := range c.Rules {
+		r := &c.Rules[i]
+		if r.Name == "" {
+			r.Name = fmt.Sprintf("rule-%d", i)
+		}
+		if r.Cmd == "" {
+			return fmt.Errorf("build.rules[%d] (%s): cmd is required", i, r.Name)
+		}
+		if len(r.IncludeDir) == 0 && len(r.IncludeExt) == 0 && len(r.IncludeFile) == 0 {
+			return fmt.Errorf("build.rules[%d] (%s): at least one of include_dir, include_ext or include_file is required", i, r.Name)
+		}
+		r.includeDirAbs = r.includeDirAbs[:0]
+		for _, dir := range r.IncludeDir {
+			dir = cleanPath(dir)
+			if dir == "" {
+				continue
+			}
+			abs := filepath.Clean(dir)
+			if !filepath.IsAbs(abs) {
+				abs = filepath.Join(root, abs)
+			}
+			r.includeDirAbs = append(r.includeDirAbs, filepath.Clean(abs))
+		}
+		r.regexCompiled = r.regexCompiled[:0]
+		for _, expr := range r.ExcludeRegex {
+			re, err := regexp.Compile(expr)
+			if err != nil {
+				return fmt.Errorf("build.rules[%d] (%s): failed to compile regex %q: %w", i, r.Name, expr, err)
+			}
+			r.regexCompiled = append(r.regexCompiled, re)
+		}
+	}
+	return nil
 }
 
 func (c *cfgBuild) normalizeIncludeDirs(root string) {
@@ -610,6 +668,9 @@ func (c *Config) preprocess(args map[string]TomlInfo) error {
 
 	adaptToVariousPlatforms(c)
 	c.Build.normalizeIncludeDirs(c.Root)
+	if err = c.Build.normalizeRules(c.Root); err != nil {
+		return err
+	}
 
 	// Join runtime arguments with the configuration arguments
 	runtimeArgs := flag.Args()

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -30,6 +30,7 @@ type Engine struct {
 	running   atomic.Bool
 
 	eventCh       chan string
+	ruleEventChs  []chan string
 	watcherStopCh chan bool
 	// buildRunCh serves dual purpose:
 	// 1. As a semaphore ensuring only one build runs at a time (buffer size 1)
@@ -73,6 +74,10 @@ func NewEngineWithConfig(cfg *Config, debugMode bool) (*Engine, error) {
 		runArgs = append(runArgs, entryArgs...)
 	}
 	runArgs = append(runArgs, cfg.Build.ArgsBin...)
+	ruleEventChs := make([]chan string, len(cfg.Build.Rules))
+	for i := range ruleEventChs {
+		ruleEventChs[i] = make(chan string, 100)
+	}
 	e := Engine{
 		config:        cfg,
 		exiter:        defaultExiter{},
@@ -82,6 +87,7 @@ func NewEngineWithConfig(cfg *Config, debugMode bool) (*Engine, error) {
 		debugMode:     debugMode,
 		runArgs:       runArgs,
 		eventCh:       make(chan string, 1000),
+		ruleEventChs:  ruleEventChs,
 		watcherStopCh: make(chan bool, 10),
 		buildRunCh:    make(chan chan struct{}, 1),
 		exitCh:        make(chan bool),
@@ -149,6 +155,11 @@ func (e *Engine) watchConfiguredDirs() error {
 	for _, dir := range e.config.Build.extraIncludeDirs {
 		targets = append(targets, watchTarget{path: dir, optional: true})
 	}
+	for _, rule := range e.config.Build.Rules {
+		for _, dir := range rule.includeDirAbs {
+			targets = append(targets, watchTarget{path: dir, optional: true})
+		}
+	}
 
 	seen := make(map[string]struct{}, len(targets))
 	for _, target := range targets {
@@ -197,12 +208,16 @@ func (e *Engine) watching(root string) error {
 		if isHiddenDirectory(path) {
 			return filepath.SkipDir
 		}
-		// exclude user specified directories
-		if e.isExcludeDir(path) {
+		// exclude user specified directories, except a rule's own include_dir:
+		// rules watch their dirs even when the main build excludes them
+		if e.isExcludeDir(path) && !e.isRuleDir(path) {
 			e.watcherLog("!exclude %s", e.config.rel(path))
 			return filepath.SkipDir
 		}
 		isIn, walkDir := e.checkIncludeDir(path)
+		if e.inRuleDir(path) {
+			isIn, walkDir = true, true
+		}
 		if !walkDir {
 			e.watcherLog("!exclude %s", e.config.rel(path))
 			return filepath.SkipDir
@@ -328,6 +343,17 @@ func (e *Engine) watchPath(path string) error {
 					e.watchNewDir(ev.Name, removeEvent(ev))
 					break
 				}
+				// rules take precedence: a file matched by a rule runs the
+				// rule's cmd and never triggers a rebuild
+				if idx := e.matchRuleIndex(ev.Name); idx >= 0 {
+					e.watcherDebug("%s matches rule %s", e.config.rel(ev.Name), e.config.Build.Rules[idx].Name)
+					select {
+					case e.ruleEventChs[idx] <- ev.Name:
+					default:
+						// channel full means a run is already queued
+					}
+					break
+				}
 				if e.isExcludeFile(ev.Name) {
 					break
 				}
@@ -361,7 +387,7 @@ func (e *Engine) watchNewDir(dir string, removeDir bool) {
 	if e.isTestDataDir(dir) {
 		return
 	}
-	if isHiddenDirectory(dir) || e.isExcludeDir(dir) {
+	if isHiddenDirectory(dir) || (e.isExcludeDir(dir) && !e.isRuleDir(dir)) {
 		e.watcherLog("!exclude %s", e.config.rel(dir))
 		return
 	}
@@ -401,6 +427,11 @@ func (e *Engine) start() {
 	}
 
 	e.running.Store(true)
+
+	for i := range e.config.Build.Rules {
+		go e.runRule(i)
+	}
+
 	firstRunCh := make(chan bool, 1)
 	firstRunCh <- true
 

--- a/runner/rule.go
+++ b/runner/rule.go
@@ -1,0 +1,118 @@
+package runner
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// matchRuleIndex returns the index of the first rule matching path, or -1.
+// Rules are checked before the main build filters, so a file matched by a
+// rule never triggers a rebuild.
+func (e *Engine) matchRuleIndex(path string) int {
+	for i := range e.config.Build.Rules {
+		if e.ruleMatches(&e.config.Build.Rules[i], path) {
+			return i
+		}
+	}
+	return -1
+}
+
+func (e *Engine) ruleMatches(r *cfgRule, path string) bool {
+	if len(r.includeDirAbs) > 0 {
+		inDir := false
+		cleaned := filepath.Clean(path)
+		for _, dir := range r.includeDirAbs {
+			if isSubPath(dir, cleaned) {
+				inDir = true
+				break
+			}
+		}
+		if !inDir {
+			return false
+		}
+	}
+	for _, re := range r.regexCompiled {
+		if re.MatchString(path) {
+			return false
+		}
+	}
+	if len(r.IncludeExt) == 0 && len(r.IncludeFile) == 0 {
+		return true
+	}
+	ext := filepath.Ext(path)
+	for _, v := range r.IncludeExt {
+		v = strings.TrimSpace(v)
+		if v == extWildcard || ext == "."+v {
+			return true
+		}
+	}
+	rel := cleanPath(e.config.rel(path))
+	for _, f := range r.IncludeFile {
+		if f == rel {
+			return true
+		}
+	}
+	return false
+}
+
+// isRuleDir reports whether dir is exactly a rule's include_dir. Such dirs
+// are watched even when the main build excludes them via exclude_dir.
+func (e *Engine) isRuleDir(dir string) bool {
+	cleaned := filepath.Clean(dir)
+	for i := range e.config.Build.Rules {
+		for _, d := range e.config.Build.Rules[i].includeDirAbs {
+			if d == cleaned {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// inRuleDir reports whether dir is a rule's include_dir or inside one.
+func (e *Engine) inRuleDir(dir string) bool {
+	cleaned := filepath.Clean(dir)
+	for i := range e.config.Build.Rules {
+		for _, d := range e.config.Build.Rules[i].includeDirAbs {
+			if isSubPath(d, cleaned) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (e *Engine) ruleLog(name string, format string, v ...interface{}) {
+	e.runnerLog("[%s] %s", name, fmt.Sprintf(format, v...))
+}
+
+// runRule consumes change events for one rule, debounces them, and runs the
+// rule's cmd. The cmd runs to completion; events arriving meanwhile stay
+// queued and trigger another run afterwards.
+func (e *Engine) runRule(idx int) {
+	rule := &e.config.Build.Rules[idx]
+	ch := e.ruleEventChs[idx]
+	for {
+		select {
+		case <-e.exitCh:
+			return
+		case filename := <-ch:
+			time.Sleep(rule.delay())
+			// coalesce the burst of events into a single run
+			for drained := false; !drained; {
+				select {
+				case <-ch:
+				default:
+					drained = true
+				}
+			}
+			e.ruleLog(rule.Name, "%s has changed", e.config.rel(filename))
+			e.ruleLog(rule.Name, "> %s", rule.Cmd)
+			if err := e.runCommand(rule.Cmd); err != nil {
+				e.ruleLog(rule.Name, "failed to execute cmd: %s", err.Error())
+			}
+		}
+	}
+}

--- a/runner/rule.go
+++ b/runner/rule.go
@@ -48,9 +48,9 @@ func (e *Engine) ruleMatches(r *cfgRule, path string) bool {
 			return true
 		}
 	}
-	rel := cleanPath(e.config.rel(path))
+	rel := filepath.ToSlash(cleanPath(e.config.rel(path)))
 	for _, f := range r.IncludeFile {
-		if f == rel {
+		if filepath.ToSlash(f) == rel {
 			return true
 		}
 	}

--- a/runner/rule_test.go
+++ b/runner/rule_test.go
@@ -1,0 +1,167 @@
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeRules(t *testing.T) {
+	root := t.TempDir()
+
+	t.Run("defaults and dir normalization", func(t *testing.T) {
+		b := cfgBuild{Rules: []cfgRule{{Cmd: "npm run build", IncludeDir: []string{"web"}, ExcludeRegex: []string{`\.map$`}}}}
+		require.NoError(t, b.normalizeRules(root))
+		rule := b.Rules[0]
+		assert.Equal(t, "rule-0", rule.Name)
+		assert.Equal(t, []string{filepath.Join(root, "web")}, rule.includeDirAbs)
+		assert.Len(t, rule.regexCompiled, 1)
+		assert.Equal(t, 1000*time.Millisecond, rule.delay())
+	})
+
+	t.Run("cmd is required", func(t *testing.T) {
+		b := cfgBuild{Rules: []cfgRule{{Name: "assets", IncludeDir: []string{"web"}}}}
+		err := b.normalizeRules(root)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cmd is required")
+	})
+
+	t.Run("at least one matcher is required", func(t *testing.T) {
+		b := cfgBuild{Rules: []cfgRule{{Cmd: "true"}}}
+		err := b.normalizeRules(root)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "at least one of")
+	})
+
+	t.Run("invalid regex", func(t *testing.T) {
+		b := cfgBuild{Rules: []cfgRule{{Cmd: "true", ExcludeRegex: []string{"("}}}}
+		require.Error(t, b.normalizeRules(root))
+	})
+}
+
+func TestRuleTomlParsing(t *testing.T) {
+	config := `
+[build]
+cmd = "go build -o ./tmp/main ."
+
+[[build.rules]]
+name = "assets"
+include_dir = ["web"]
+include_ext = ["js", "css"]
+cmd = "npm run build"
+delay = 200
+`
+	path := filepath.Join(t.TempDir(), ".air.toml")
+	require.NoError(t, os.WriteFile(path, []byte(config), 0o644))
+
+	cfg, err := readConfig(path)
+	require.NoError(t, err)
+	require.Len(t, cfg.Build.Rules, 1)
+	rule := cfg.Build.Rules[0]
+	assert.Equal(t, "assets", rule.Name)
+	assert.Equal(t, "npm run build", rule.Cmd)
+	assert.Equal(t, []string{"web"}, rule.IncludeDir)
+	assert.Equal(t, []string{"js", "css"}, rule.IncludeExt)
+	assert.Equal(t, 200*time.Millisecond, rule.delay())
+}
+
+func TestRuleMatches(t *testing.T) {
+	root := t.TempDir()
+	cfg := defaultConfig()
+	cfg.Root = root
+	cfg.Build.Rules = []cfgRule{{
+		Name:         "assets",
+		Cmd:          "true",
+		IncludeDir:   []string{"web"},
+		IncludeExt:   []string{"js"},
+		IncludeFile:  []string{"web/vite.config"},
+		ExcludeRegex: []string{`\.min\.js$`},
+	}}
+	require.NoError(t, cfg.Build.normalizeRules(root))
+	e := &Engine{config: &cfg}
+
+	tests := []struct {
+		path  string
+		match bool
+	}{
+		{filepath.Join(root, "web", "app.js"), true},
+		{filepath.Join(root, "web", "deep", "nested.js"), true},
+		{filepath.Join(root, "web", "app.min.js"), false}, // exclude_regex
+		{filepath.Join(root, "web", "index.html"), false}, // ext not matched
+		{filepath.Join(root, "web", "vite.config"), true}, // include_file
+		{filepath.Join(root, "cmd", "app.js"), false},     // outside include_dir
+		{filepath.Join(root, "main.go"), false},
+	}
+	for _, tt := range tests {
+		idx := e.matchRuleIndex(tt.path)
+		assert.Equal(t, tt.match, idx >= 0, "path: %s", tt.path)
+	}
+
+	assert.True(t, e.isRuleDir(filepath.Join(root, "web")))
+	assert.False(t, e.isRuleDir(filepath.Join(root, "web", "deep")))
+	assert.True(t, e.inRuleDir(filepath.Join(root, "web", "deep")))
+	assert.False(t, e.inRuleDir(filepath.Join(root, "cmd")))
+}
+
+// TestRuleRunsCmdWithoutRebuild verifies the core behavior of issue #540: a
+// change in a rule's directory runs the rule cmd and does not rebuild the app,
+// even when that directory is listed in the main build's exclude_dir.
+func TestRuleRunsCmdWithoutRebuild(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires sh")
+	}
+
+	tmpDir := t.TempDir()
+	t.Setenv(airWd, tmpDir)
+	chdir(t, tmpDir)
+
+	config := `
+[build]
+cmd = "echo built >> builds.txt"
+full_bin = "true" # exits immediately
+include_ext = ["go"]
+exclude_dir = ["web"]
+
+[[build.rules]]
+name = "assets"
+include_dir = ["web"]
+include_ext = ["js"]
+cmd = "echo asset >> asset_builds.txt"
+delay = 100
+`
+	require.NoError(t, os.WriteFile(dftTOML, []byte(config), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "web"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "web", "app.js"), []byte("a"), 0o644))
+
+	engine, err := NewEngine(dftTOML, nil, false)
+	require.NoError(t, err)
+	go engine.Run()
+	defer engine.Stop()
+
+	time.Sleep(time.Second)
+
+	countLines := func(name string) int {
+		bytes, err := os.ReadFile(name)
+		if err != nil {
+			return 0
+		}
+		return len(strings.Split(strings.TrimSpace(string(bytes)), "\n"))
+	}
+
+	// first run builds the app once, the rule cmd has not run
+	assert.Equal(t, 1, countLines("builds.txt"))
+	assert.Equal(t, 0, countLines("asset_builds.txt"))
+
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "web", "app.js"), []byte("b"), 0o644))
+
+	time.Sleep(2 * time.Second)
+
+	assert.Equal(t, 1, countLines("asset_builds.txt"), "rule cmd should have run once")
+	assert.Equal(t, 1, countLines("builds.txt"), "changing a rule file must not rebuild the app")
+}

--- a/runner/util.go
+++ b/runner/util.go
@@ -492,6 +492,11 @@ func setTage2Map(root string, t reflect.Type, v reflect.Value, m map[string]Toml
 			continue
 		}
 
+		// slices of tables (e.g. build.rules) cannot be expressed as CLI flags
+		if field.Type.Kind() == reflect.Slice && field.Type.Elem().Kind() == reflect.Struct {
+			continue
+		}
+
 		tomlPath := root + tomlVal
 		path := fieldPath + field.Name
 		var v *string


### PR DESCRIPTION
## Summary

Adds `[[build.rules]]` config blocks: each rule watches a set of files and runs a command when they change, instead of rebuilding and restarting the main binary.

Addresses #540 — the frontend-assets case from the issue description, plus the `go generate`/templ/sqlc cases raised in comments (a rule's cmd can generate files the main build watches, e.g. `.go` files, and the rebuild cascades naturally with no extra flag needed).

```toml
[build]
cmd = "go build -o ./tmp/main ."
exclude_dir = ["web"]  # main build ignores the frontend...

[[build.rules]]
name = "assets"
include_dir = ["web"]   # ...but this rule watches it anyway
include_ext = ["js", "ts", "css"]
cmd = "npm run build"
```

### Design notes
- Rule directories are watched even when listed in `exclude_dir` (only the directory itself; explicit excludes of subdirectories like `node_modules` still apply).
- A file matched by a rule runs the rule's `cmd` and never triggers the main rebuild — checked before the main build's include/exclude filters.
- Each rule gets its own goroutine with a buffered event channel, per-rule debounce (`delay`, default 1000ms), and burst coalescing (rapid changes collapse into one run).
- Rule commands run to completion; changes arriving while one is running queue a single follow-up run.
- Validation requires `cmd` and at least one of `include_dir`/`include_ext`/`include_file`; a rule without a `name` defaults to `rule-<index>`.
- CLI flag generation (`flatConfig`) now skips slices-of-structs, since `build.rules` can't be expressed as a single flag — this previously would have panicked.

## Test plan
- [x] `go test ./runner/` — full suite passes, including new `runner/rule_test.go` (config validation/parsing, rule matching, and an end-to-end engine test proving a rule fires its cmd and skips a rebuild)
- [x] `gofmt -l` / `go vet` clean
- [x] Manually built the binary and drove a scratch project: verified initial build, asset-only changes (no rebuild), normal `.go` changes (rebuild as before), debounce/coalescing on a burst of writes, new-subdirectory watching, cascading rebuild via a `go generate`-style rule, a failing rule cmd (air keeps running), and a missing `cmd` field (clean startup error)
- [x] Updated `README.md` and `air_example.toml` with the new config

🤖 Generated with [Claude Code](https://claude.com/claude-code)