### PR TITLE
ci: add release-please for automated versioning and releases

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,17 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,20 @@
+name: Release Please
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          # Must be a PAT (or GitHub App token), not the default GITHUB_TOKEN:
+          # tags pushed with GITHUB_TOKEN do not trigger the release.yml workflow.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          release-type: go

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,7 @@
+release:
+  # release-please creates the GitHub release with the changelog;
+  # goreleaser only uploads artifacts to it.
+  mode: keep-existing
 builds:
   - goos:
       - linux


### PR DESCRIPTION
## Summary
Automates version bumps and releases with release-please: it maintains a release PR on master, computes the next semver from conventional commits, and on merge tags the release — which triggers the existing goreleaser + Docker flow unchanged.

## Changes
- Add `.github/workflows/release-please.yml`: runs on every push to master, keeps a release PR up to date with pending changes and changelog; merging it creates the tag and GitHub release (`fix:` → patch, `feat:` → minor, `feat!:`/`BREAKING CHANGE` → major)
- Add `.github/workflows/pr-title.yml`: validates PR titles against Conventional Commits (via `amannn/action-semantic-pull-request`), so squash-merged commits are always classifiable by release-please
- Set `release.mode: keep-existing` in `.goreleaser.yml` so goreleaser uploads artifacts to the release created by release-please instead of overwriting its changelog notes

## Setup required after merge
- Add a repo secret `RELEASE_PLEASE_TOKEN` (fine-grained PAT with Contents: write + Pull requests: write). Tags pushed with the default `GITHUB_TOKEN` do not trigger `release.yml`, so this is required for goreleaser to run
- Enable squash merge (and preferably disable merge commits) so the validated PR title becomes the commit message

## Testing
- Workflow YAML validated locally; release-please takes effect once merged to master
- After merge: release-please should open a release PR bumping from v1.65.3; merging that PR should tag, run goreleaser, and push the Docker image

## Screenshots
N/A

## Checklist
- [ ] Tests pass
- [ ] Documentation updated
- [ ] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)