### PR TITLE
feat: allow slice flags to be repeated on the command line

### DIFF
--- a/runner/flag.go
+++ b/runner/flag.go
@@ -2,13 +2,49 @@ package runner
 
 import (
 	"flag"
+	"reflect"
 )
+
+// appendableValue is a flag.Value for slice-typed config fields. The first
+// occurrence replaces the default, every later occurrence appends, so
+// `-env_files a,b -env_files c` is equivalent to `-env_files a,b,c`.
+type appendableValue struct {
+	p   *string
+	set bool
+}
+
+func (v *appendableValue) String() string {
+	if v == nil || v.p == nil {
+		return ""
+	}
+	return *v.p
+}
+
+func (v *appendableValue) Set(s string) error {
+	switch {
+	case !v.set:
+		*v.p = s
+	case s == "":
+		// nothing to append
+	case *v.p == "":
+		*v.p = s
+	default:
+		*v.p += sliceCmdArgSeparator + s
+	}
+	v.set = true
+	return nil
+}
 
 // ParseConfigFlag parse toml information for flag
 func ParseConfigFlag(f *flag.FlagSet) map[string]TomlInfo {
 	c := defaultConfig()
 	m := flatConfig(c)
 	for k, v := range m {
+		if v.field.Type.Kind() == reflect.Slice {
+			*v.Value = v.fieldValue
+			f.Var(&appendableValue{p: v.Value}, k, v.usage)
+			continue
+		}
 		f.StringVar(v.Value, k, v.fieldValue, v.usage)
 	}
 	return m

--- a/runner/flag_test.go
+++ b/runner/flag_test.go
@@ -54,6 +54,18 @@ func TestFlag(t *testing.T) {
 			expected: `["_test.go"]`,
 			key:      "build.exclude_regex",
 		},
+		{
+			name:     "repeated slice flag appends",
+			args:     []string{"--env_files", "a,b", "--env_files", "c", "--env_files", "d,e"},
+			expected: "a,b,c,d,e",
+			key:      "env_files",
+		},
+		{
+			name:     "repeated slice flag overrides default on first use",
+			args:     []string{"--build.exclude_dir", "foo", "--build.exclude_dir", "bar"},
+			expected: "foo,bar",
+			key:      "build.exclude_dir",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Slice-typed config flags can now be passed multiple times, with values appended in the order they appear. Closes the request in #913.

`air -env_files a,b -env_files c` is now equivalent to `air -env_files a,b,c`.

## Changes

- `runner/flag.go`: added `appendableValue`, a `flag.Value` that replaces the default on first use and appends with `,` on every later occurrence
- `runner/flag.go`: `ParseConfigFlag` registers slice-typed fields with `flag.Var` instead of `flag.StringVar`; scalar fields are unchanged
- `runner/flag_test.go`: cases for repeated appends and for the first occurrence overriding a non-empty default

Because the branch is taken on `reflect.Slice`, this covers every slice field — `env_files`, `build.exclude_dir`, `build.args_bin`, `build.entrypoint`, and so on — which is the "bonus" asked for in the issue.

The downstream path is untouched: `setValue2Struct` already splits these values on `,`.

### Motivation

Quoting the issue, `.env` file paths can be generated dynamically with names that are not predictable, e.g. a Makefile assembling a dev environment:

```makefile
ifneq (,$(wildcard $(EXTERNAL_DOTENV_FILEPATH)))
	AIR_OPTS+=-env_files $(EXTERNAL_DOTENV_FILEPATH)
endif
ifneq (,$(wildcard $(LOCAL_OVERRIDE_DOTENV_FILEPATH)))
	AIR_OPTS+=-env_files $(LOCAL_OVERRIDE_DOTENV_FILEPATH)
endif
```

Appending one flag per discovered file is much easier to script than building a single comma-joined value.

### One behavior note

`air --help` now renders slice flags as `value` rather than `string`, and their defaults unquoted:

```
-build.exclude_dir value
    Ignore these filename extensions or directories (default assets,tmp,vendor,testdata)
```

This is what `flag.PrintDefaults` does for non-builtin types. Restoring `string` would mean putting a backquoted type name in each `usage` tag in `config.go` — happy to do that if preferred.

## Testing

```bash
go test ./runner/
```

Verified end to end against a scratch project with two env files:

```bash
air -env_files .env1 -env_files .env2
# running...
# A= 1 B= 2
```

## Screenshots

N/A

## Checklist

- [x] Tests pass
- [ ] Documentation updated
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)