### PR TITLE
fix: don't let a transient empty read defeat exclude_unchanged

### DIFF
--- a/runner/engine.go
+++ b/runner/engine.go
@@ -283,7 +283,7 @@ func (e *Engine) cacheFileChecksums(root string) error {
 		}
 
 		// update the checksum cache for the current file
-		_ = e.isModified(path)
+		e.primeChecksum(path)
 
 		return nil
 	})
@@ -404,8 +404,20 @@ func (e *Engine) watchNewDir(dir string, removeDir bool) {
 	}(dir)
 }
 
+// primeChecksum records a file's current checksum without waiting for any
+// in-flight write. Used when seeding the cache at startup, where nothing is
+// being written and every wait would be pure startup latency.
+func (e *Engine) primeChecksum(filename string) {
+	checksum, err := fileChecksum(filename)
+	if err != nil {
+		e.watcherDebug("can't cache checksum for %s: %v", e.config.rel(filename), err)
+		return
+	}
+	e.fileChecksums.updateFileChecksum(filename, checksum)
+}
+
 func (e *Engine) isModified(filename string) bool {
-	newChecksum, err := fileChecksum(filename)
+	newChecksum, err := settledFileChecksum(filename)
 	if err != nil {
 		e.watcherDebug("can't determine if file was changed: %v - assuming it did without updating cache", err)
 		return true

--- a/runner/util.go
+++ b/runner/util.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 )
@@ -341,6 +342,19 @@ func adaptToVariousPlatforms(c *Config) {
 	}
 }
 
+// errEmptyFile is returned when a file reads back as zero bytes. The read may
+// have landed in the middle of somebody else's write, so no checksum is stored.
+var errEmptyFile = errors.New("empty file, forcing rebuild without updating checksum")
+
+// Writers that truncate before writing (shell redirection, os.Create, editors
+// running format-on-save) leave the file at zero bytes for a moment. Reading it
+// there reports a change that never happened, so give the writer a bounded
+// chance to finish before deciding. See air-verse/air#527.
+const (
+	emptyReadRetries    = 5
+	emptyReadRetryDelay = 20 * time.Millisecond
+)
+
 // fileChecksum returns a checksum for the given file's contents.
 func fileChecksum(filename string) (checksum string, err error) {
 	contents, err := os.ReadFile(filename)
@@ -352,7 +366,7 @@ func fileChecksum(filename string) (checksum string, err error) {
 	// This can happen often if editors are configured to run format after save.
 	// Instead of calculating a new checksum, we'll assume the file was unchanged, but return an error to force a rebuild anyway.
 	if len(contents) == 0 {
-		return "", errors.New("empty file, forcing rebuild without updating checksum")
+		return "", errEmptyFile
 	}
 
 	h := sha256.New()
@@ -361,6 +375,19 @@ func fileChecksum(filename string) (checksum string, err error) {
 	}
 
 	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// settledFileChecksum is fileChecksum for live change events, where the write
+// that triggered the event may still be in flight. A file that stays empty for
+// the whole retry budget is treated as genuinely empty.
+func settledFileChecksum(filename string) (checksum string, err error) {
+	for attempt := 0; ; attempt++ {
+		checksum, err = fileChecksum(filename)
+		if !errors.Is(err, errEmptyFile) || attempt == emptyReadRetries {
+			return checksum, err
+		}
+		time.Sleep(emptyReadRetryDelay)
+	}
 }
 
 // checksumMap is a thread-safe map to store file checksums.

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -330,6 +330,133 @@ func TestFileChecksum(t *testing.T) {
 	}
 }
 
+// TestIsModifiedDuringTruncatingWrite reproduces air-verse/air#527.
+//
+// Generators that write with shell redirection (`cat > gen.go <<EOF`) truncate
+// the file before the content is written, so a watcher event can arrive while
+// the file is zero bytes. fileChecksum reports an error for an empty file and
+// isModified turns any error into "the file changed", which silently defeats
+// exclude_unchanged: air rebuilds, the build regenerates the file, and the
+// loop never settles even though the generated content is identical each run.
+func TestIsModifiedDuringTruncatingWrite(t *testing.T) {
+	t.Parallel()
+
+	const generated = "package main\n\nconst GeneratedValue = \"stable-output\"\n"
+
+	newEngine := func(t *testing.T) *Engine {
+		t.Helper()
+		return &Engine{
+			config:        &Config{},
+			fileChecksums: &checksumMap{m: make(map[string]string)},
+		}
+	}
+
+	t.Run("rewriting identical content in place is skipped", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "gen.go")
+		require.NoError(t, os.WriteFile(path, []byte(generated), 0o644))
+
+		e := newEngine(t)
+		require.True(t, e.isModified(path), "first sighting of a file always counts as modified")
+
+		// A generator that does not truncate leaves the checksum intact.
+		require.NoError(t, os.WriteFile(path, []byte(generated), 0o644))
+		require.False(t, e.isModified(path), "identical content must not trigger a rebuild")
+	})
+
+	t.Run("truncate then write identical content is not skipped", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "gen.go")
+		require.NoError(t, os.WriteFile(path, []byte(generated), 0o644))
+
+		e := newEngine(t)
+		require.True(t, e.isModified(path), "first sighting of a file always counts as modified")
+		require.False(t, e.isModified(path), "checksum cache should be primed")
+
+		// Simulate `cat > gen.go <<EOF`: the shell truncates the file, then the
+		// content is written by a separate process a moment later.
+		f, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0o644)
+		require.NoError(t, err)
+
+		written := make(chan struct{})
+		go func() {
+			defer close(written)
+			time.Sleep(30 * time.Millisecond)
+			_, _ = f.WriteString(generated)
+			_ = f.Close()
+		}()
+
+		// The watcher event for the truncation arrives here, while the file is
+		// still empty. The content that eventually lands is byte-for-byte the
+		// same as what is already cached, so this must not force a rebuild.
+		modified := e.isModified(path)
+		<-written
+
+		require.Equal(t, generated, readFileString(t, path), "generator must produce identical content")
+		require.False(t, modified, "a transient empty read must not defeat exclude_unchanged")
+	})
+
+	t.Run("file that stays empty still counts as modified", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "gen.go")
+		require.NoError(t, os.WriteFile(path, []byte(generated), 0o644))
+
+		e := newEngine(t)
+		require.True(t, e.isModified(path), "first sighting of a file always counts as modified")
+		require.False(t, e.isModified(path), "checksum cache should be primed")
+
+		// Emptying a file is a real change, not a write in flight. Waiting out
+		// the retry budget must not turn it into "unchanged".
+		require.NoError(t, os.WriteFile(path, nil, 0o644))
+		require.True(t, e.isModified(path), "a genuinely empty file must still trigger a rebuild")
+	})
+}
+
+func TestSettledFileChecksum(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns errEmptyFile once the retry budget is spent", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "empty.go")
+		require.NoError(t, os.WriteFile(path, nil, 0o644))
+
+		start := time.Now()
+		_, err := settledFileChecksum(path)
+		elapsed := time.Since(start)
+
+		require.ErrorIs(t, err, errEmptyFile)
+		require.GreaterOrEqual(t, elapsed, emptyReadRetryDelay*emptyReadRetries,
+			"should exhaust the retry budget before giving up")
+	})
+
+	t.Run("does not wait for a file that already has content", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "full.go")
+		require.NoError(t, os.WriteFile(path, []byte("package main\n"), 0o644))
+
+		start := time.Now()
+		checksum, err := settledFileChecksum(path)
+
+		require.NoError(t, err)
+		require.NotEmpty(t, checksum)
+		require.Less(t, time.Since(start), emptyReadRetryDelay, "non-empty reads must not sleep")
+	})
+
+	t.Run("propagates errors other than empty reads", func(t *testing.T) {
+		t.Parallel()
+		_, err := settledFileChecksum(filepath.Join(t.TempDir(), "missing.go"))
+		require.Error(t, err)
+		require.NotErrorIs(t, err, errEmptyFile)
+	})
+}
+
+func readFileString(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(b)
+}
+
 func TestChecksumMap(t *testing.T) {
 	t.Parallel()
 	m := &checksumMap{m: make(map[string]string, 3)}


### PR DESCRIPTION
Closes #527

## Problem

When code generation runs as part of the build and writes into a watched directory, air can get stuck in a loop: codegen → rebuild → codegen → rebuild. The documented workaround is `exclude_unchanged = true`, which compares checksums and skips rebuilds when content did not actually change.

That workaround is silently defeated when the generator writes by truncating first. Shell redirection (`cat > gen.go <<EOF`) truncates the file when the redirection is set up, *before* `cat` is even forked, so the file sits at zero bytes for a measurable window. A watcher event fired in that window leads to:

```
fileChecksum   -> error("empty file, ...")   // runner/util.go
isModified     -> treats any error as "changed", returns true
exclude_unchanged -> bypassed entirely, rebuild forced
```

The rebuild regenerates the file, which fires another event, and the loop never settles — even though the generated content is byte-for-byte identical every run.

## Scope

This only affects generators that write via shell redirection. Generators that write in-process (`os.Create` + write — sqlc, oapi-codegen, and most real tools) close the window in microseconds and were verified not to trigger it, at both small and 2.5 MB output sizes.

`isModified` is only called when `exclude_unchanged` is enabled, so default setups see no behaviour change at all.

## Fix

Retry the read a bounded number of times (5 × 20ms) when a file reads back empty, and only on live change events, where the write that triggered the event may still be in flight.

Seeding the checksum cache at startup now goes through a new `primeChecksum` helper that does **not** retry — nothing is being written at that point, so waiting there would be pure startup latency for every genuinely empty file in the repo.

`errors.New` became an `errEmptyFile` sentinel so `errors.Is` can tell an empty read apart from a real I/O error; without that, the retry loop would swallow and retry every error. The message text is unchanged.

Semantics deliberately preserved, each covered by a test:

- a file that stays empty for the whole budget is still reported as modified
- non-empty reads never sleep
- errors other than empty reads propagate untouched

## Verification

Reproduction lives at [air-reproducible-example/issue-527-codegen-rebuild-loop](https://github.com/air-verse/air-reproducible-example), which pairs a shell generator (reproduces) with a Go generator producing identical output (control, does not reproduce).

20-second runs, counting `building...` lines:

| Build command | Before | After |
| --- | --- | --- |
| `sh gen.sh && go build ...` | 20 rebuilds, 0 skips | **1 rebuild, 2 skips** |
| `go run ./gen && go build ...` | 1 rebuild, 1 skip | 1 rebuild, 1 skip |

- `TestIsModifiedDuringTruncatingWrite` fails on `master` and passes with this change; verified stable over `-count=20` and under `-race`.
- `go test ./...` passes.
- `hack/check.sh scope=all` reports 0 issues.

## Note on the original request

The issue also asks for a time-based option ("ignore changes for N seconds after a build"). That is not implemented here, and I'd argue it is the wrong axis — build durations vary, so any fixed window is either too short or needlessly slow. Content comparison is the more robust mechanism, which is why this change makes the existing one actually work.

Worth calling out that `exclude_unchanged` can only ever help **idempotent** generators. If a generator embeds a timestamp or other varying content, the checksum legitimately differs every run and no comparison can break the loop; `exclude_regex` is the tool for that case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
