### PR TITLE
fix: consume watcher events in a single loop

### DIFF
--- a/runner/engine.go
+++ b/runner/engine.go
@@ -13,6 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/gohugoio/hugo/watcher/filenotify"
 	"github.com/joho/godotenv"
 )
@@ -28,6 +29,10 @@ type Engine struct {
 	debugMode bool
 	runArgs   []string
 	running   atomic.Bool
+	// eventLoops counts live runEventLoop goroutines. Exactly one should ever
+	// run; watched paths are registered with the shared watcher instead of
+	// each getting its own consumer (air-verse/air#918).
+	eventLoops atomic.Int32
 
 	eventCh       chan string
 	ruleEventChs  []chan string
@@ -46,7 +51,6 @@ type Engine struct {
 	exitCh    chan bool
 
 	mu            sync.RWMutex
-	watchers      uint
 	fileChecksums *checksumMap
 
 	ll sync.Mutex // lock for logger
@@ -92,7 +96,6 @@ func NewEngineWithConfig(cfg *Config, debugMode bool) (*Engine, error) {
 		buildRunCh:    make(chan chan struct{}, 1),
 		exitCh:        make(chan bool),
 		fileChecksums: &checksumMap{m: make(map[string]string)},
-		watchers:      0,
 		globalEnv:     map[string]*string{},
 	}
 
@@ -126,6 +129,12 @@ func (e *Engine) Run() {
 	if err = e.checkRunEnv(); err != nil {
 		os.Exit(1)
 	}
+
+	// Start consuming before the initial walk registers paths. The walk can
+	// take a while on a large tree, and nothing else drains the watcher, so a
+	// later start would let the kernel queue overflow and drop events.
+	go e.runEventLoop()
+
 	if err = e.watchConfiguredDirs(); err != nil {
 		os.Exit(1)
 	}
@@ -306,6 +315,12 @@ func (e *Engine) rewatchFile(name string) {
 
 }
 
+// watchPath registers path with the shared watcher. It is safe to call again
+// for a path that is already watched: the watcher deduplicates, and event
+// handling lives in a single loop rather than one consumer per path. Spawning
+// a consumer per path used to leak a goroutine every time an already-watched
+// directory produced an event, which Docker volume drivers do routinely
+// (see air-verse/air#918).
 func (e *Engine) watchPath(path string) error {
 	if err := e.watcher.Add(path); err != nil {
 		e.watcherLog("failed to watch %s, error: %s", path, err.Error())
@@ -313,71 +328,82 @@ func (e *Engine) watchPath(path string) error {
 	}
 	e.watcherLog("watching %s", e.config.rel(path))
 
-	go func() {
-		e.withLock(func() {
-			e.watchers++
-		})
-		defer func() {
-			e.withLock(func() {
-				e.watchers--
-			})
-		}()
-
-		if e.config.Build.ExcludeUnchanged {
-			err := e.cacheFileChecksums(path)
-			if err != nil {
+	if e.config.Build.ExcludeUnchanged {
+		// Seed in the background so a large tree does not hold up the first
+		// build. This is a one-shot walk, not a long-lived consumer.
+		go func() {
+			if err := e.cacheFileChecksums(path); err != nil {
 				e.watcherLog("error building checksum cache: %v", err)
 			}
-		}
+		}()
+	}
+	return nil
+}
 
-		for {
-			select {
-			case <-e.watcherStopCh:
+// runEventLoop consumes watcher events for the lifetime of the engine. Exactly
+// one instance runs, started by start().
+func (e *Engine) runEventLoop() {
+	e.eventLoops.Add(1)
+	defer e.eventLoops.Add(-1)
+
+	for {
+		select {
+		case <-e.watcherStopCh:
+			return
+		case ev, ok := <-e.watcher.Events():
+			if !ok {
 				return
-			case ev := <-e.watcher.Events():
-				e.mainDebug("event: %+v", ev)
-				if !validEvent(ev) {
-					break
-				}
-				if isDir(ev.Name) {
-					e.watchNewDir(ev.Name, removeEvent(ev))
-					break
-				}
-				// rules take precedence: a file matched by a rule runs the
-				// rule's cmd and never triggers a rebuild
-				if idx := e.matchRuleIndex(ev.Name); idx >= 0 {
-					e.watcherDebug("%s matches rule %s", e.config.rel(ev.Name), e.config.Build.Rules[idx].Name)
-					select {
-					case e.ruleEventChs[idx] <- ev.Name:
-					default:
-						// channel full means a run is already queued
-					}
-					break
-				}
-				if e.isExcludeFile(ev.Name) {
-					break
-				}
-				excludeRegex, _ := e.isExcludeRegex(ev.Name)
-				if excludeRegex {
-					break
-				}
-				if !e.isIncludeExt(ev.Name) && !e.checkIncludeFile(ev.Name) {
-					break
-				}
-				// Rewatch the file if the editor is using atomic saving.
-				if renameOrRemoveEvent(ev) {
-					if e.checkIncludeFile(ev.Name) {
-						go e.rewatchFile(ev.Name)
-					}
-				}
-				e.watcherDebug("%s has changed", e.config.rel(ev.Name))
-				e.eventCh <- ev.Name
-			case err := <-e.watcher.Errors():
+			}
+			e.handleWatchEvent(ev)
+		case err, ok := <-e.watcher.Errors():
+			if !ok {
+				return
+			}
+			if err != nil {
 				e.watcherLog("error: %s", err.Error())
 			}
 		}
-	}()
-	return nil
+	}
+}
+
+func (e *Engine) handleWatchEvent(ev fsnotify.Event) {
+	e.mainDebug("event: %+v", ev)
+	if !validEvent(ev) {
+		return
+	}
+	if isDir(ev.Name) {
+		e.watchNewDir(ev.Name, removeEvent(ev))
+		return
+	}
+	// rules take precedence: a file matched by a rule runs the
+	// rule's cmd and never triggers a rebuild
+	if idx := e.matchRuleIndex(ev.Name); idx >= 0 {
+		e.watcherDebug("%s matches rule %s", e.config.rel(ev.Name), e.config.Build.Rules[idx].Name)
+		select {
+		case e.ruleEventChs[idx] <- ev.Name:
+		default:
+			// channel full means a run is already queued
+		}
+		return
+	}
+	if e.isExcludeFile(ev.Name) {
+		return
+	}
+	excludeRegex, _ := e.isExcludeRegex(ev.Name)
+	if excludeRegex {
+		return
+	}
+	if !e.isIncludeExt(ev.Name) && !e.checkIncludeFile(ev.Name) {
+		return
+	}
+	// Rewatch the file if the editor is using atomic saving.
+	if renameOrRemoveEvent(ev) {
+		if e.checkIncludeFile(ev.Name) {
+			go e.rewatchFile(ev.Name)
+		}
+	}
+	e.watcherDebug("%s has changed", e.config.rel(ev.Name))
+	e.eventCh <- ev.Name
 }
 
 func (e *Engine) watchNewDir(dir string, removeDir bool) {
@@ -886,11 +912,10 @@ func (e *Engine) cleanup() {
 	e.stopBin()
 	e.mainDebug("waiting for close watchers..")
 
-	e.withLock(func() {
-		for i := 0; i < int(e.watchers); i++ {
-			e.watcherStopCh <- true
-		}
-	})
+	// A single event loop consumes watcher events, so one signal stops it.
+	// The channel is buffered, so this does not block if the loop already
+	// returned because the watcher was closed.
+	e.watcherStopCh <- true
 
 	e.mainDebug("waiting for buildRun...")
 	var err error

--- a/runner/engine_test.go
+++ b/runner/engine_test.go
@@ -1831,3 +1831,90 @@ TEST_GLOBAL_VAR=still_overridden
 	assert.Equal(t, "final_value", os.Getenv("TEST_VAR1"), "TEST_VAR1 should be final")
 	assert.Equal(t, originalValue, os.Getenv("TEST_GLOBAL_VAR"), "TEST_GLOBAL_VAR should be restored to original value")
 }
+
+func newWatchTestEngine(t *testing.T, root string) *Engine {
+	t.Helper()
+	cfg := &Config{Root: root, TmpDir: "tmp", TestDataDir: "testdata"}
+	cfg.Build.IncludeExt = []string{"go"}
+	cfg.Log.Silent = true
+	watcher, err := newWatcher(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = watcher.Close() })
+	return &Engine{
+		config:        cfg,
+		logger:        newLogger(cfg),
+		watcher:       watcher,
+		watcherStopCh: make(chan bool, 10),
+		eventCh:       make(chan string, 100),
+		fileChecksums: &checksumMap{m: make(map[string]string)},
+	}
+}
+
+// TestWatchPathIsIdempotent covers air-verse/air#918. Docker volume drivers
+// emit events named for directories that are already watched. Handling one
+// used to spawn a fresh watcher consumer every time, leaking a goroutine per
+// event; event handling now lives in a single loop instead.
+func TestWatchPathIsIdempotent(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "internal")
+	require.NoError(t, os.Mkdir(sub, 0o755))
+
+	e := newWatchTestEngine(t, root)
+	require.NoError(t, e.watching(root))
+
+	go e.runEventLoop()
+	require.Eventually(t, func() bool { return e.eventLoops.Load() == 1 },
+		2*time.Second, 10*time.Millisecond, "the single event loop should start")
+
+	// Re-register the root and an already-watched subdirectory, which is what
+	// an event naming either of them triggers via watchNewDir.
+	for i := 0; i < 10; i++ {
+		require.NoError(t, e.watchPath(root))
+		require.NoError(t, e.watchPath(sub))
+	}
+	time.Sleep(200 * time.Millisecond)
+
+	require.Equal(t, int32(1), e.eventLoops.Load(),
+		"re-watching a watched path must not spawn another event loop")
+}
+
+// TestWatchNewDirOnWatchedDirDoesNotLeak exercises the same guarantee through
+// the call the event loop actually makes for a directory event.
+func TestWatchNewDirOnWatchedDirDoesNotLeak(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "internal")
+	require.NoError(t, os.Mkdir(sub, 0o755))
+
+	e := newWatchTestEngine(t, root)
+	require.NoError(t, e.watching(root))
+
+	go e.runEventLoop()
+	require.Eventually(t, func() bool { return e.eventLoops.Load() == 1 },
+		2*time.Second, 10*time.Millisecond, "the single event loop should start")
+
+	for i := 0; i < 10; i++ {
+		e.watchNewDir(root, false)
+		e.watchNewDir(sub, false)
+	}
+	time.Sleep(500 * time.Millisecond)
+
+	require.Equal(t, int32(1), e.eventLoops.Load(),
+		"repeated directory events must not accumulate event loops")
+}
+
+// TestEventLoopStopsOnSignal keeps cleanup() honest: it now sends exactly one
+// stop signal, so one signal must end the loop.
+func TestEventLoopStopsOnSignal(t *testing.T) {
+	root := t.TempDir()
+	e := newWatchTestEngine(t, root)
+	require.NoError(t, e.watching(root))
+
+	go e.runEventLoop()
+	require.Eventually(t, func() bool { return e.eventLoops.Load() == 1 },
+		2*time.Second, 10*time.Millisecond, "the single event loop should start")
+
+	e.watcherStopCh <- true
+
+	require.Eventually(t, func() bool { return e.eventLoops.Load() == 0 },
+		2*time.Second, 10*time.Millisecond, "one signal must stop the event loop")
+}


### PR DESCRIPTION
Closes #918

## Problem

`watchPath` spawned a goroutine per watched path. That goroutine was never actually tied to its path — it read the shared `e.watcher.Events()` channel, so N watched directories meant N identical consumers competing over one queue.

The event loop dispatches directory events like this:

```go
if isDir(ev.Name) {
    e.watchNewDir(ev.Name, removeEvent(ev))
}
```

`isDir()` answers *"is this path a directory"*, not *"is this a new directory"*. Any event naming an already-watched directory therefore went back through `watchNewDir` → `watching` → `watchPath` and leaked another consumer:

```
baseline watchers = 1
after root event 1: watchers = 2
after root event 2: watchers = 3
...
after root event 5: watchers = 6
```

Unbounded, and not specific to the root — an already-watched `internal/` behaves identically.

Linux inotify almost never emits events for directories that already exist (a change inside a directory is reported against the child file), which is why this went unnoticed. Docker Desktop's gRPC-FUSE / virtiofs layer emits them routinely, so the reporter's bind-mount setup is what made it visible — the environment is the developer, not the cause.

## On the fix proposed in the issue

The issue suggests skipping events whose name resolves to the watched root. That does address the reported symptom, but it targets the narrower path. Two things are worth separating:

- **`isDir` transiently failing** (the issue's diagnosis) can only cause a spurious *rebuild* when `include_ext = ["*"]`. With the default extension list, `filepath.Ext("/src")` is empty, so the event is dropped at the `include_ext` gate even if it slips past `isDir`.
- **`isDir` succeeding** — the common case — reaches `watchNewDir` and leaks a consumer. This needs no stat failure and is unaffected by `include_ext`.

So the leak is the more frequent problem, and skipping the root would still leave every subdirectory exposed.

## Fix

Register paths with the shared watcher, and consume events in exactly one loop:

- `watchPath` only calls `watcher.Add` (which deduplicates) and seeds checksums in a one-shot goroutine when `exclude_unchanged` is on.
- `runEventLoop` runs once for the engine's lifetime; the event body moves to `handleWatchEvent`.
- `cleanup` sends one stop signal instead of `watchers` of them; the counter is gone.

Repeated registration is now inert by construction, so there is no idempotency invariant left to enforce, and every already-watched directory is covered rather than just the root.

The loop starts *before* the initial walk. Previously the first `watchPath` began draining partway through the walk; starting it in `start()` would leave the walk undrained, and a large tree could overflow the kernel queue and drop events.

Two latent bugs in the loop are fixed while it moves: a closed `Errors()` channel yields a nil error whose `.Error()` panicked, and a closed `Events()` channel spun the loop. Both now exit cleanly.

## Verification

- `TestWatchPathIsIdempotent`, `TestWatchNewDirOnWatchedDirDoesNotLeak`, `TestEventLoopStopsOnSignal` — stable over `-count=5 -race`.
- Full `go test ./runner` run 3× on this branch and 3× on `master`: 0 failures on both.
- `hack/check.sh scope=all`: 0 issues.

**Caveat on the tests:** they reference `runEventLoop`, so they cannot compile against `master` and are not red-before-green. They lock in the new invariant; the evidence that the leak existed is the goroutine counts above, measured on `master` before the change. Happy to swap in a version that counts `watchPath.func1` stack frames instead — that one compiles against both and fails on `master` — if you would rather have a test a reviewer can watch fail.

## Behaviour notes

`exclude_unchanged` seeding stays asynchronous, so the first build is not delayed. Event handling becomes serial rather than spread across N consumers; the handlers only filter and push to the buffered `eventCh`, and the previous consumers all blocked on that same send when it was full, so the throughput characteristics are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
