### PR TITLE
test: stop config warning tests from racing on os.Stderr

### DIFF
--- a/runner/config.go
+++ b/runner/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	pathpkg "path"
@@ -12,6 +13,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"dario.cat/mergo"
@@ -28,6 +30,20 @@ const (
 
 	schemaHeader = "#:schema https://json.schemastore.org/any.json"
 )
+
+// warnOut is where configuration warnings are written, guarded by warnMu. It
+// exists so tests can capture or silence warnings without swapping the
+// process-wide os.Stderr, which races with tests running in parallel.
+var (
+	warnMu  sync.Mutex
+	warnOut io.Writer = os.Stderr
+)
+
+func warnf(format string, a ...any) {
+	warnMu.Lock()
+	defer warnMu.Unlock()
+	fmt.Fprintf(warnOut, format+"\n", a...)
+}
 
 // Config is the main configuration structure for Air.
 type Config struct {
@@ -637,7 +653,7 @@ func (c *Config) preprocess(args map[string]TomlInfo) error {
 		if !c.Build.IgnoreDangerousRootDir {
 			return fmt.Errorf("refusing to run in %s - this would watch too many files. Please run air in a project directory", dirName)
 		}
-		fmt.Fprintln(os.Stderr, "[warning] ignoring root directory protections. This could cause excessive file watching. It is recommended to run air in a project directory")
+		warnf("[warning] ignoring root directory protections. This could cause excessive file watching. It is recommended to run air in a project directory")
 	}
 
 	if c.TmpDir == "" {
@@ -910,5 +926,5 @@ func warnDeprecatedBin(cfg *Config, binExplicit bool) {
 		return
 	}
 
-	fmt.Fprintln(os.Stderr, "[warning] build.bin is deprecated; set build.entrypoint instead")
+	warnf("[warning] build.bin is deprecated; set build.entrypoint instead")
 }

--- a/runner/config_test.go
+++ b/runner/config_test.go
@@ -2,7 +2,6 @@ package runner
 
 import (
 	"flag"
-	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -653,37 +652,19 @@ func TestInitConfigWithoutConfigDoesNotWarnDeprecatedBin(t *testing.T) {
 		}
 	})
 
-	oldStderr := os.Stderr
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("failed to create pipe: %v", err)
-	}
-	os.Stderr = w
-	t.Cleanup(func() {
-		os.Stderr = oldStderr
-	})
+	warnings := captureWarnings(t)
 
 	if _, err := InitConfig("", nil); err != nil {
 		t.Fatalf("InitConfig returned error: %v", err)
 	}
 
-	if err := w.Close(); err != nil {
-		t.Fatalf("failed to close writer: %v", err)
-	}
-
-	out, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatalf("failed to read output: %v", err)
-	}
-
-	output := string(out)
+	output := warnings()
 	if strings.Contains(output, "build.bin is deprecated") {
 		t.Fatalf("unexpected bin deprecation warning in output: %q", output)
 	}
 }
 
 func TestWarnDeprecatedBin(t *testing.T) {
-	t.Parallel()
 	tmpDir := t.TempDir()
 	cfgPath := filepath.Join(tmpDir, ".air.toml")
 	cfgContent := `
@@ -695,25 +676,11 @@ cmd = "go build -o ./tmp/main ."
 		t.Fatalf("failed to write config: %v", err)
 	}
 
-	oldStderr := os.Stderr
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("failed to create pipe: %v", err)
-	}
-	os.Stderr = w
+	warnings := captureWarnings(t)
 
 	_, _ = InitConfig(cfgPath, nil)
 
-	if err := w.Close(); err != nil {
-		t.Fatalf("failed to close writer: %v", err)
-	}
-	os.Stderr = oldStderr
-
-	out, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatalf("failed to read output: %v", err)
-	}
-	output := string(out)
+	output := warnings()
 	if !strings.Contains(output, "build.bin is deprecated") {
 		t.Fatalf("missing bin deprecation warning in output: %q", output)
 	}
@@ -929,7 +896,9 @@ func TestTmpDirAdjustsDefaultsWindows(t *testing.T) {
 }
 
 func TestTmpDirDoesNotOverrideExplicitCmd(t *testing.T) {
-	t.Parallel()
+	// Not parallel: build.bin triggers a deprecation warning, and warnOut is
+	// process-wide, so this must not overlap tests capturing warnings.
+	silenceWarnings(t)
 	tmpDir := t.TempDir()
 	cfgPath := filepath.Join(tmpDir, ".air.toml")
 	cfgContent := `tmp_dir = ".tmp"
@@ -1061,25 +1030,11 @@ ignore_dangerous_root_dir = true
 			t.Fatalf("failed to write config: %v", err)
 		}
 
-		oldStderr := os.Stderr
-		r, w, err := os.Pipe()
-		if err != nil {
-			t.Fatalf("failed to create pipe: %v", err)
-		}
-		os.Stderr = w
+		warnings := captureWarnings(t)
 
 		_, _ = InitConfig(cfgPath, nil)
 
-		if err := w.Close(); err != nil {
-			t.Fatalf("failed to close writer: %v", err)
-		}
-		os.Stderr = oldStderr
-
-		out, err := io.ReadAll(r)
-		if err != nil {
-			t.Fatalf("failed to read output: %v", err)
-		}
-		output := string(out)
+		output := warnings()
 		if !strings.Contains(output, "ignoring root directory protections. This could cause excessive file watching. It is recommended to run air in a project directory") {
 			t.Fatalf("missing root directory protection warning in output: %q", output)
 		}
@@ -1098,25 +1053,11 @@ ignore_dangerous_root_dir = false
 			t.Fatalf("failed to write config: %v", err)
 		}
 
-		oldStderr := os.Stderr
-		r, w, err := os.Pipe()
-		if err != nil {
-			t.Fatalf("failed to create pipe: %v", err)
-		}
-		os.Stderr = w
+		warnings := captureWarnings(t)
 
 		_, _ = InitConfig(cfgPath, nil)
 
-		if err := w.Close(); err != nil {
-			t.Fatalf("failed to close writer: %v", err)
-		}
-		os.Stderr = oldStderr
-
-		out, err := io.ReadAll(r)
-		if err != nil {
-			t.Fatalf("failed to read output: %v", err)
-		}
-		output := string(out)
+		output := warnings()
 		if strings.Contains(output, "ignoring root directory protections") {
 			t.Fatalf("unexpected root directory protection warning in output: %q", output)
 		}
@@ -1135,25 +1076,11 @@ cmd = "go build -o ./tmp/main ."
 			t.Fatalf("failed to write config: %v", err)
 		}
 
-		oldStderr := os.Stderr
-		r, w, err := os.Pipe()
-		if err != nil {
-			t.Fatalf("failed to create pipe: %v", err)
-		}
-		os.Stderr = w
+		warnings := captureWarnings(t)
 
 		_, _ = InitConfig(cfgPath, nil)
 
-		if err := w.Close(); err != nil {
-			t.Fatalf("failed to close writer: %v", err)
-		}
-		os.Stderr = oldStderr
-
-		out, err := io.ReadAll(r)
-		if err != nil {
-			t.Fatalf("failed to read output: %v", err)
-		}
-		output := string(out)
+		output := warnings()
 		if strings.Contains(output, "ignoring root directory protections") {
 			t.Fatalf("unexpected root directory protection warning in output: %q", output)
 		}

--- a/runner/flag_test.go
+++ b/runner/flag_test.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"flag"
 	"log"
-	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -203,7 +202,7 @@ func TestConfigRuntimeArgs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
 			chdir(t, dir)
-			silenceStderr(t)
+			silenceWarnings(t)
 			flag := flag.NewFlagSet(t.Name(), flag.ExitOnError)
 			cmdArgs := ParseConfigFlag(flag)
 			require.NoError(t, flag.Parse(tc.args))
@@ -215,19 +214,4 @@ func TestConfigRuntimeArgs(t *testing.T) {
 			tc.check(t, cfg)
 		})
 	}
-}
-
-// silenceStderr redirects os.Stderr to the OS null device for the lifetime
-// of the test, hiding warnings (e.g. the build.bin deprecation notice) that
-// would otherwise leak into test output.
-func silenceStderr(t *testing.T) {
-	t.Helper()
-	orig := os.Stderr
-	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
-	require.NoError(t, err)
-	os.Stderr = devNull
-	t.Cleanup(func() {
-		os.Stderr = orig
-		_ = devNull.Close()
-	})
 }

--- a/runner/warn_test.go
+++ b/runner/warn_test.go
@@ -1,0 +1,44 @@
+package runner
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+// swapWarnOut points warnOut at w until the test ends.
+func swapWarnOut(t *testing.T, w io.Writer) {
+	t.Helper()
+	warnMu.Lock()
+	orig := warnOut
+	warnOut = w
+	warnMu.Unlock()
+	t.Cleanup(func() {
+		warnMu.Lock()
+		warnOut = orig
+		warnMu.Unlock()
+	})
+}
+
+// captureWarnings collects configuration warnings emitted during the test and
+// returns them via the returned func, which may be called more than once.
+//
+// Tests using it must not call t.Parallel(): warnOut is process-wide, so a
+// concurrent test emitting warnings would end up in this buffer.
+func captureWarnings(t *testing.T) func() string {
+	t.Helper()
+	var buf bytes.Buffer
+	swapWarnOut(t, &buf)
+	return func() string {
+		warnMu.Lock()
+		defer warnMu.Unlock()
+		return buf.String()
+	}
+}
+
+// silenceWarnings discards configuration warnings (e.g. the build.bin
+// deprecation notice) that would otherwise leak into test output.
+func silenceWarnings(t *testing.T) {
+	t.Helper()
+	swapWarnOut(t, io.Discard)
+}


### PR DESCRIPTION
## Problem

`TestWarnDeprecatedBin` fails intermittently on CI:

```
config_test.go:718: missing bin deprecation warning in output: ""
--- FAIL: TestWarnDeprecatedBin (0.00s)
```

(e.g. [run 29926422749](https://github.com/air-verse/air/actions/runs/29926422749/job/88944646846); the macOS job in that run was only cancelled by fail-fast.)

The cause is that several tests swap the process-wide `os.Stderr` while running in parallel:

- `TestWarnDeprecatedBin` (and 4 other tests) point it at an `os.Pipe` to capture warnings,
- `silenceStderr` in `flag_test.go` points it at `/dev/null`,
- `warnDeprecatedBin` reads `os.Stderr` only at write time.

So whichever assignment happens to be in effect when `InitConfig` warns decides where the message goes. In the failing run the warning leaked to the real test output while the capturing pipe read back `""`.

## Fix

- Route the two configuration warnings in `config.go` through a package-level `warnOut io.Writer` guarded by `warnMu`, via a small `warnf` helper. Production behaviour is unchanged (`warnOut` defaults to `os.Stderr`).
- Add `captureWarnings(t)` / `silenceWarnings(t)` test helpers (`runner/warn_test.go`) that swap only `warnOut` and never touch `os.Stderr`.
- Drop `t.Parallel()` from the tests that capture warnings, and from `TestTmpDirDoesNotOverrideExplicitCmd` (its config sets `build.bin`, so it emits a deprecation warning that could otherwise land in another test's buffer); it now silences warnings instead.
- Remove `silenceStderr`, replaced by `silenceWarnings`.

## Testing

- `go vet ./runner/` clean.
- `go test ./runner/ -count=20 -run 'Warn|TmpDir|InitConfig|TestFlag|TestConfigRuntimeArgs'` passes.
- `go test ./runner/ -count=1` (and with `-race`) leaves only failures that also reproduce on `master` in the same environment: `TestRebuildWhenRunCmdUsingDLV` (no `dlv` installed locally) and, under `-race`, `TestShouldIncludeGoTestFile` / `TestShouldIncludeIncludedFileWithoutIncludedExt`. These are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)