### PR TITLE
test: cover proxy handlers, entrypoint parsing, logger and checksum paths

### DIFF
--- a/runner/config_test.go
+++ b/runner/config_test.go
@@ -314,6 +314,22 @@ func TestReadConfigWithWrongPath(t *testing.T) {
 	}
 }
 
+func TestBuildAndRerunDelay(t *testing.T) {
+	t.Parallel()
+	config := Config{
+		Build: cfgBuild{
+			Delay:      300,
+			RerunDelay: 700,
+		},
+	}
+	if got, want := config.buildDelay(), 300*time.Millisecond; got != want {
+		t.Fatalf("buildDelay() = %v, want %v", got, want)
+	}
+	if got, want := config.rerunDelay(), 700*time.Millisecond; got != want {
+		t.Fatalf("rerunDelay() = %v, want %v", got, want)
+	}
+}
+
 func TestKillDelay(t *testing.T) {
 	t.Parallel()
 	config := Config{

--- a/runner/engine_checksum_test.go
+++ b/runner/engine_checksum_test.go
@@ -101,7 +101,9 @@ func TestEngineIsExcludeFile(t *testing.T) {
 
 	cfg := defaultConfig()
 	cfg.Root = tmpDir
-	cfg.Build.ExcludeFile = []string{"skip.go", "docs/*.md"}
+	// isExcludeFile matches with filepath.Match, so the directory pattern has
+	// to use the platform separator to match on Windows too.
+	cfg.Build.ExcludeFile = []string{"skip.go", filepath.Join("docs", "*.md")}
 	require.NoError(t, cfg.preprocess(nil))
 
 	engine, err := NewEngineWithConfig(&cfg, false)

--- a/runner/engine_checksum_test.go
+++ b/runner/engine_checksum_test.go
@@ -1,0 +1,115 @@
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeFile creates path (including parents) with the given contents.
+func writeFile(t *testing.T, path, contents string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o644))
+}
+
+func TestEngineCacheFileChecksums(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	writeFile(t, filepath.Join(tmpDir, "main.go"), "package main\n")
+	writeFile(t, filepath.Join(tmpDir, "internal", "app.go"), "package internal\n")
+	writeFile(t, filepath.Join(tmpDir, "README.md"), "docs\n")           // extension not watched
+	writeFile(t, filepath.Join(tmpDir, "skip.go"), "package skip\n")     // exclude_file
+	writeFile(t, filepath.Join(tmpDir, "app_test.go"), "package main\n") // exclude_regex
+	writeFile(t, filepath.Join(tmpDir, "tmp", "main.go"), "package tmp\n")
+	writeFile(t, filepath.Join(tmpDir, "vendor", "dep.go"), "package dep\n")
+	writeFile(t, filepath.Join(tmpDir, ".hidden", "hidden.go"), "package hidden\n")
+
+	cfg := defaultConfig()
+	cfg.Root = tmpDir
+	cfg.TmpDir = "tmp"
+	cfg.Build.IncludeExt = []string{"go"}
+	cfg.Build.ExcludeDir = []string{"vendor"}
+	cfg.Build.ExcludeFile = []string{"skip.go"}
+	cfg.Build.ExcludeRegex = []string{"_test.go"}
+	require.NoError(t, cfg.preprocess(nil))
+
+	engine, err := NewEngineWithConfig(&cfg, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = engine.watcher.Close() })
+
+	require.NoError(t, engine.cacheFileChecksums(cfg.Root))
+
+	cached := func(rel string) bool {
+		path := filepath.Join(cfg.Root, rel)
+		checksum, err := fileChecksum(path)
+		require.NoError(t, err)
+		// updateFileChecksum reports false when the checksum is already stored.
+		return !engine.fileChecksums.updateFileChecksum(path, checksum)
+	}
+
+	assert.True(t, cached("main.go"), "watched file should be cached")
+	assert.True(t, cached(filepath.Join("internal", "app.go")), "watched file in subdir should be cached")
+
+	assert.False(t, cached("README.md"), "unwatched extension should not be cached")
+	assert.False(t, cached("skip.go"), "exclude_file match should not be cached")
+	assert.False(t, cached("app_test.go"), "exclude_regex match should not be cached")
+	assert.False(t, cached(filepath.Join("vendor", "dep.go")), "exclude_dir content should not be cached")
+	assert.False(t, cached(filepath.Join(".hidden", "hidden.go")), "hidden dir content should not be cached")
+}
+
+func TestEngineCacheFileChecksumsMissingRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg := defaultConfig()
+	cfg.Root = tmpDir
+	require.NoError(t, cfg.preprocess(nil))
+
+	engine, err := NewEngineWithConfig(&cfg, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = engine.watcher.Close() })
+
+	assert.Error(t, engine.cacheFileChecksums(filepath.Join(tmpDir, "does-not-exist")))
+}
+
+func TestEnginePrimeChecksumIgnoresUnreadableFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg := defaultConfig()
+	cfg.Root = tmpDir
+	require.NoError(t, cfg.preprocess(nil))
+
+	engine, err := NewEngineWithConfig(&cfg, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = engine.watcher.Close() })
+
+	missing := filepath.Join(tmpDir, "gone.go")
+	engine.primeChecksum(missing)
+
+	// Nothing was stored, so the first real update reports a change.
+	writeFile(t, missing, "package main\n")
+	checksum, err := fileChecksum(missing)
+	require.NoError(t, err)
+	assert.True(t, engine.fileChecksums.updateFileChecksum(missing, checksum))
+}
+
+func TestEngineIsExcludeFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg := defaultConfig()
+	cfg.Root = tmpDir
+	cfg.Build.ExcludeFile = []string{"skip.go", "docs/*.md"}
+	require.NoError(t, cfg.preprocess(nil))
+
+	engine, err := NewEngineWithConfig(&cfg, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = engine.watcher.Close() })
+
+	assert.True(t, engine.isExcludeFile(filepath.Join(cfg.Root, "skip.go")))
+	assert.True(t, engine.isExcludeFile(filepath.Join(cfg.Root, "docs", "readme.md")))
+	assert.False(t, engine.isExcludeFile(filepath.Join(cfg.Root, "main.go")))
+	assert.False(t, engine.isExcludeFile(filepath.Join(cfg.Root, "docs", "nested", "readme.md")))
+}

--- a/runner/entrypoint_test.go
+++ b/runner/entrypoint_test.go
@@ -1,0 +1,85 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEntrypointUnmarshalTOML(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   interface{}
+		want    entrypoint
+		wantErr string
+	}{
+		{
+			name:  "nil clears the entrypoint",
+			value: nil,
+			want:  nil,
+		},
+		{
+			name:  "string becomes a single element",
+			value: "./tmp/main",
+			want:  entrypoint{"./tmp/main"},
+		},
+		{
+			name:  "array keeps binary and args",
+			value: []interface{}{"./tmp/main", "server", ":8080"},
+			want:  entrypoint{"./tmp/main", "server", ":8080"},
+		},
+		{
+			name:  "empty array yields an empty entrypoint",
+			value: []interface{}{},
+			want:  entrypoint{},
+		},
+		{
+			name:    "non-string array element is rejected",
+			value:   []interface{}{"./tmp/main", 42},
+			wantErr: "entrypoint values must be strings, got int",
+		},
+		{
+			name:    "unsupported type is rejected",
+			value:   42,
+			wantErr: "entrypoint must be a string or array of strings, got int",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Start from a non-empty value so nil is seen to clear it.
+			e := entrypoint{"stale"}
+			err := e.UnmarshalTOML(tt.value)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, e)
+		})
+	}
+}
+
+func TestEntrypointBinaryAndArgs(t *testing.T) {
+	t.Parallel()
+
+	var empty entrypoint
+	assert.Empty(t, empty.binary())
+	assert.Nil(t, empty.args())
+
+	single := entrypoint{"./tmp/main"}
+	assert.Equal(t, "./tmp/main", single.binary())
+	assert.Nil(t, single.args())
+
+	withArgs := entrypoint{"./tmp/main", "server", ":8080"}
+	assert.Equal(t, "./tmp/main", withArgs.binary())
+	assert.Equal(t, []string{"server", ":8080"}, withArgs.args())
+}

--- a/runner/flag_value_test.go
+++ b/runner/flag_value_test.go
@@ -1,0 +1,70 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppendableValueString(t *testing.T) {
+	t.Parallel()
+
+	var nilValue *appendableValue
+	assert.Empty(t, nilValue.String(), "nil receiver should stringify to empty")
+
+	assert.Empty(t, (&appendableValue{}).String(), "nil target should stringify to empty")
+
+	s := "a,b"
+	assert.Equal(t, "a,b", (&appendableValue{p: &s}).String())
+}
+
+func TestAppendableValueSet(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		initial string
+		sets    []string
+		want    string
+	}{
+		{
+			name:    "first set replaces the default",
+			initial: "default",
+			sets:    []string{"a"},
+			want:    "a",
+		},
+		{
+			name:    "later sets append",
+			initial: "default",
+			sets:    []string{"a", "b,c"},
+			want:    "a" + sliceCmdArgSeparator + "b,c",
+		},
+		{
+			name:    "empty append is ignored",
+			initial: "default",
+			sets:    []string{"a", ""},
+			want:    "a",
+		},
+		{
+			name:    "append onto an emptied value does not add a separator",
+			initial: "default",
+			sets:    []string{"", "b"},
+			want:    "b",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			target := tt.initial
+			v := &appendableValue{p: &target}
+			for _, s := range tt.sets {
+				require.NoError(t, v.Set(s))
+			}
+			assert.Equal(t, tt.want, target)
+			assert.Equal(t, tt.want, v.String())
+		})
+	}
+}

--- a/runner/logger_extra_test.go
+++ b/runner/logger_extra_test.go
@@ -2,7 +2,6 @@ package runner
 
 import (
 	"bytes"
-	"regexp"
 	"testing"
 
 	"github.com/fatih/color"
@@ -80,7 +79,7 @@ func TestNewLogFuncAddsTime(t *testing.T) {
 
 	out := buf.String()
 	assert.Contains(t, out, "hello air")
-	assert.Regexp(t, regexp.MustCompile(`^\[\d{2}:\d{2}:\d{2}\] `), out)
+	assert.Regexp(t, `^\[\d{2}:\d{2}:\d{2}\] `, out)
 }
 
 func TestNewLoggerReturnsNilWithoutConfig(t *testing.T) {

--- a/runner/logger_extra_test.go
+++ b/runner/logger_extra_test.go
@@ -1,0 +1,90 @@
+package runner
+
+import (
+	"bytes"
+	"regexp"
+	"testing"
+
+	"github.com/fatih/color"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureColorOutput redirects the writer fatih/color logs to, so colored log
+// lines can be asserted on instead of leaking into the test output.
+func captureColorOutput(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	orig := color.Error
+	origNoColor := color.NoColor
+	color.Error = &buf
+	color.NoColor = true
+	t.Cleanup(func() {
+		color.Error = orig
+		color.NoColor = origNoColor
+	})
+	return &buf
+}
+
+func TestGetColorFallsBackToWhite(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, color.FgRed, getColor("red"))
+	assert.Equal(t, color.FgWhite, getColor("white"))
+	assert.Equal(t, color.FgWhite, getColor("not-a-color"))
+}
+
+func TestGetLoggerFallsBackToRawLogger(t *testing.T) {
+	// Not parallel: captureColorOutput swaps package-level color state.
+	buf := captureColorOutput(t)
+
+	cfg := defaultConfig()
+	l := newLogger(&cfg)
+	require.NotNil(t, l)
+
+	// Known names come from the configured loggers.
+	assert.NotNil(t, l.main())
+	assert.NotNil(t, l.build())
+	assert.NotNil(t, l.runner())
+	assert.NotNil(t, l.watcher())
+
+	// An unknown name falls back to the raw logger, which still logs.
+	l.getLogger("no-such-logger")("fallback message")
+	assert.NotNil(t, rawLogger())
+	assert.Empty(t, buf.String(), "raw logger should not write through color.Error")
+}
+
+func TestNewLogFuncSilentSkipsOutput(t *testing.T) {
+	buf := captureColorOutput(t)
+
+	logFn := newLogFunc("white", cfgLog{Silent: true})
+	logFn("should not be printed")
+
+	assert.Empty(t, buf.String())
+}
+
+func TestNewLogFuncSkipsEmptyMessage(t *testing.T) {
+	buf := captureColorOutput(t)
+
+	logFn := newLogFunc("white", cfgLog{})
+	logFn("   \n  ")
+
+	assert.Empty(t, buf.String())
+}
+
+func TestNewLogFuncAddsTime(t *testing.T) {
+	buf := captureColorOutput(t)
+
+	logFn := newLogFunc("white", cfgLog{AddTime: true})
+	logFn("hello %s", "air")
+
+	out := buf.String()
+	assert.Contains(t, out, "hello air")
+	assert.Regexp(t, regexp.MustCompile(`^\[\d{2}:\d{2}:\d{2}\] `), out)
+}
+
+func TestNewLoggerReturnsNilWithoutConfig(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, newLogger(nil))
+}

--- a/runner/proxy_handler_test.go
+++ b/runner/proxy_handler_test.go
@@ -1,0 +1,163 @@
+package runner
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingStreamer records the calls Proxy forwards to its Streamer.
+type recordingStreamer struct {
+	reloads      int
+	buildFailure BuildFailedMsg
+	stopped      bool
+}
+
+func (s *recordingStreamer) AddSubscriber() *Subscriber { return &Subscriber{} }
+func (s *recordingStreamer) RemoveSubscriber(int32)     {}
+func (s *recordingStreamer) Reload()                    { s.reloads++ }
+func (s *recordingStreamer) BuildFailed(m BuildFailedMsg) {
+	s.buildFailure = m
+}
+func (s *recordingStreamer) Stop() { s.stopped = true }
+
+// nonFlusherRecorder is an http.ResponseWriter that deliberately does not
+// implement http.Flusher, so handlers take their "streaming unsupported" path.
+type nonFlusherRecorder struct {
+	header http.Header
+	body   strings.Builder
+	code   int
+}
+
+func newNonFlusherRecorder() *nonFlusherRecorder {
+	return &nonFlusherRecorder{header: make(http.Header), code: http.StatusOK}
+}
+
+func (w *nonFlusherRecorder) Header() http.Header { return w.header }
+
+func (w *nonFlusherRecorder) Write(b []byte) (int, error) { return w.body.Write(b) }
+
+func (w *nonFlusherRecorder) WriteHeader(code int) { w.code = code }
+
+func TestProxy_workerScriptHandler(t *testing.T) {
+	proxy := NewProxy(&cfgProxy{Enabled: true, ProxyPort: 1111, AppPort: 1112})
+
+	rec := httptest.NewRecorder()
+	proxy.workerScriptHandler(rec, httptest.NewRequest(http.MethodGet, "/__air_internal/worker.js", nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "application/javascript", rec.Header().Get("Content-Type"))
+	assert.Equal(t, WorkerScript, rec.Body.String())
+}
+
+func TestProxy_ReloadAndBuildFailedDelegateToStream(t *testing.T) {
+	stream := &recordingStreamer{}
+	proxy := NewProxy(&cfgProxy{Enabled: true, ProxyPort: 1111, AppPort: 1112})
+	proxy.stream = stream
+
+	proxy.Reload()
+	proxy.Reload()
+	assert.Equal(t, 2, stream.reloads)
+
+	msg := BuildFailedMsg{Error: "boom"}
+	proxy.BuildFailed(msg)
+	assert.Equal(t, msg, stream.buildFailure)
+}
+
+func TestProxy_reloadHandlerWithoutFlusher(t *testing.T) {
+	stream := &recordingStreamer{}
+	proxy := NewProxy(&cfgProxy{Enabled: true, ProxyPort: 1111, AppPort: 1112})
+	proxy.stream = stream
+
+	w := newNonFlusherRecorder()
+	proxy.reloadHandler(w, httptest.NewRequest(http.MethodGet, "/__air_internal/sse", nil))
+
+	assert.Equal(t, http.StatusInternalServerError, w.code)
+	assert.Contains(t, w.body.String(), "streaming unsupported")
+}
+
+func TestProxy_proxyHandlerStreamingWithoutFlusher(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "data: hello\n\n")
+	}))
+	defer srv.Close()
+
+	proxy := NewProxy(&cfgProxy{Enabled: true, ProxyPort: 1111, AppPort: getServerPort(t, srv)})
+
+	w := newNonFlusherRecorder()
+	proxy.proxyHandler(w, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	assert.Equal(t, http.StatusInternalServerError, w.code)
+	assert.Contains(t, w.body.String(), "streaming not supported")
+}
+
+func TestProxy_proxyHandlerBadForm(t *testing.T) {
+	proxy := NewProxy(&cfgProxy{Enabled: true, ProxyPort: 1111, AppPort: 1112})
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("%zz=1"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	rec := httptest.NewRecorder()
+	proxy.proxyHandler(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Body.String(), "bad form")
+}
+
+func TestProxy_proxyHandlerInvalidMethod(t *testing.T) {
+	proxy := NewProxy(&cfgProxy{Enabled: true, ProxyPort: 1111, AppPort: 1112})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	// A method with a space is rejected by http.NewRequest.
+	req.Method = "BAD METHOD"
+
+	rec := httptest.NewRecorder()
+	proxy.proxyHandler(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Body.String(), "unable to create request")
+}
+
+// errWriter fails every write, exercising streamCopy's error handling.
+type errWriter struct{ err error }
+
+func (w errWriter) Write([]byte) (int, error) { return 0, w.err }
+
+// shortWriter reports fewer written bytes than it was given.
+type shortWriter struct{}
+
+func (shortWriter) Write(b []byte) (int, error) { return len(b) - 1, nil }
+
+type noopFlusher struct{}
+
+func (noopFlusher) Flush() {}
+
+func TestStreamCopyWriteError(t *testing.T) {
+	wantErr := errors.New("write failed")
+
+	err := streamCopy(errWriter{err: wantErr}, strings.NewReader("hello"), noopFlusher{})
+	require.Error(t, err)
+	assert.Equal(t, wantErr, err)
+}
+
+func TestStreamCopyShortWrite(t *testing.T) {
+	err := streamCopy(shortWriter{}, strings.NewReader("hello"), noopFlusher{})
+	assert.ErrorIs(t, err, io.ErrShortWrite)
+}
+
+func TestProxy_Stop(t *testing.T) {
+	stream := &recordingStreamer{}
+	proxy := NewProxy(&cfgProxy{Enabled: true, ProxyPort: 1111, AppPort: 1112})
+	proxy.stream = stream
+
+	require.NoError(t, proxy.Stop())
+	assert.True(t, stream.stopped)
+}


### PR DESCRIPTION
## Why

Codecov sits at 73%, which renders orange-red under the default `60..80` range. This adds tests for the functions with the most uncovered statements, without touching production code.

Local `go test ./runner/ -covermode=count`: **82.5% → 85.7%**.

## What is now covered

| Area | Was | Added |
|---|---|---|
| `proxy.workerScriptHandler` | 0% | serves `worker.js` with the right content type |
| `proxy.Reload` / `BuildFailed` | 0% | delegation to the `Streamer`, plus `Stop` |
| `proxy.reloadHandler` | 88% | the "streaming unsupported" branch (writer without `http.Flusher`) |
| `proxy.proxyHandler` | 81% | bad form body, invalid method, streaming response without a flusher |
| `streamCopy` | 79% | write error and short-write paths |
| `entrypoint.UnmarshalTOML` | 21% | nil / string / array / empty array / non-string element / wrong type |
| `logger` (`rawLogger`, `getColor`, `getLogger`, `newLogFunc`) | 0-88% | raw fallback, unknown color, silent, empty message, `add_time` |
| `engine.cacheFileChecksums` | 44% | exclude_file / exclude_regex / exclude_dir / hidden dir / tmp dir / unwatched extension, plus a missing root |
| `engine.primeChecksum` | 60% | unreadable file stores nothing |
| `engine.isExcludeFile` | 50% | glob patterns, including one that should not match nested paths |
| `config.buildDelay` / `rerunDelay` | 0-100% | millisecond conversion |
| `appendableValue.String` / `Set` | 67% | nil receiver, nil target, first-set-replaces / later-appends semantics |

Logger tests redirect `color.Error` to a buffer (restored via `t.Cleanup`) so assertions are possible and no colored lines leak into test output.

## Testing

`gofmt -l runner/` and `go vet ./runner/` are clean. Full `go test ./runner/` passes except `TestRebuildWhenRunCmdUsingDLV`, which also fails on `master` in this environment because `dlv` is not installed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)