### PR TITLE
fix: stamp a real version into the docker latest image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,13 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
+      # Without a checkout, build-push-action builds from the remote Git
+      # context, which has no .git directory, so `git describe --tags` inside
+      # the image cannot stamp a version. Fetch tags for the same reason.
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
@@ -92,6 +99,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v5
         with:
+          context: .
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-AIRVER := $(shell git describe --tags)
+# Builds outside a git checkout (e.g. a Docker build context without .git) have
+# no tags to describe, so fall back instead of stamping an empty version.
+AIRVER ?= $(shell git describe --tags 2>/dev/null || echo dev)
 LDFLAGS += -X "main.BuildTimestamp=$(shell date -u "+%Y-%m-%d %H:%M:%S")"
 LDFLAGS += -X "main.airVersion=$(AIRVER)"
 LDFLAGS += -X "main.goVersion=$(shell go version | sed -r 's/go version go(.*)\ .*/\1/')"


### PR DESCRIPTION
## Problem

The `Push master code to docker latest image` job logs this on every master push (e.g. [this run](https://github.com/air-verse/air/actions/runs/30191430112/job/89765258377)):

```
#13 121.3 fatal: not a git repository (or any of the parent directories): .git
#13 121.5 error: unknown option `cached'
#13 121.5 usage: git diff --no-index [<options>] <path> <path>
```

The job has no `actions/checkout` step, so `docker/build-push-action` builds from the **remote Git context**, which BuildKit materializes as a plain directory with no `.git`. Inside the image:

- `Makefile`'s `AIRVER := $(shell git describe --tags)` fails, so `main.airVersion` is stamped **empty** — `cosmtrek/air:latest` reports no version.
- `hack/check.sh`'s `git diff --cached --name-only` fails the same way (git falls back to the `--no-index` usage, hence `unknown option 'cached'`), so the goimports step silently sees an empty file list. Linting still runs.

The build does not fail, but the published `latest` image has no version string.

## Fix

- Check out the repo (`fetch-depth: 0`, so tags are available for `git describe`) and build from the local context.
- Fall back to `dev` in the Makefile via `AIRVER ?= $(shell git describe --tags 2>/dev/null || echo dev)`, so any other git-less build produces a usable version instead of an empty one and no `fatal:` line.

## Testing

Local `docker build .` off this branch:

- zero `not a git repository` / `unknown option 'cached'` lines (was 3+ per build)
- `docker run --rm <image> -v` → `v1.67.2-3-g208af6c, built with Go 1.26.5`

Makefile fallback checked by running `make -n build` from a copy of the Makefile outside any git repo: `main.airVersion=dev`, no git error.

## Not included

The `tput: No value for $TERM and no -T specified` lines are unrelated (non-tty container) and still appear. Happy to silence those in `hack/check.sh` in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)