### PR TITLE
fix: strip hop-by-hop headers in the proxy

### DIFF
--- a/runner/proxy.go
+++ b/runner/proxy.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/textproto"
 	"strconv"
 	"strings"
 	"time"
@@ -40,6 +41,38 @@ const (
 	encodingGzip
 	encodingBrotli
 )
+
+// hopByHopHeaders are connection-specific headers, as defined by RFC 7230
+// section 6.1. A proxy must consume them itself rather than forwarding them
+// on to the next hop.
+var hopByHopHeaders = []string{
+	"Connection",
+	"Keep-Alive",
+	"Proxy-Authenticate",
+	"Proxy-Authorization",
+	"Proxy-Connection", // non-standard, but widely used
+	"Te",
+	"Trailer",
+	"Transfer-Encoding",
+	"Upgrade",
+}
+
+// delHopByHopHeaders removes the hop-by-hop headers from h, including any
+// header named by the Connection header.
+func delHopByHopHeaders(h http.Header) {
+	// The headers named by Connection must be dropped before Connection itself
+	// is removed, otherwise there is nothing left to read the names from.
+	for _, f := range h.Values("Connection") {
+		for _, sf := range strings.Split(f, ",") {
+			if sf = textproto.TrimString(sf); sf != "" {
+				h.Del(sf)
+			}
+		}
+	}
+	for _, k := range hopByHopHeaders {
+		h.Del(k)
+	}
+}
 
 type Proxy struct {
 	server *http.Server
@@ -142,6 +175,7 @@ func (p *Proxy) proxyHandler(w http.ResponseWriter, r *http.Request) {
 			req.Header.Add(name, value)
 		}
 	}
+	delHopByHopHeaders(req.Header)
 	req.Header.Set("X-Forwarded-For", r.RemoteAddr)
 
 	// set the via header
@@ -183,6 +217,9 @@ func (p *Proxy) proxyHandler(w http.ResponseWriter, r *http.Request) {
 			w.Header().Add(k, v)
 		}
 	}
+	// Only the copy in w is filtered: resp.Header is still needed intact below
+	// to detect streaming responses.
+	delHopByHopHeaders(w.Header())
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Add("Via", viaHeaderValue)
 

--- a/runner/proxy_test.go
+++ b/runner/proxy_test.go
@@ -643,6 +643,131 @@ func TestProxy_proxyHandler_NonStreaming(t *testing.T) {
 	assert.Equal(t, content, string(body))
 }
 
+func TestDelHopByHopHeaders(t *testing.T) {
+	tests := []struct {
+		name   string
+		header http.Header
+		want   http.Header
+	}{
+		{
+			name: "removes_standard_hop_by_hop_headers",
+			header: http.Header{
+				"Connection":          {"keep-alive"},
+				"Keep-Alive":          {"timeout=5"},
+				"Proxy-Authenticate":  {"Basic"},
+				"Proxy-Authorization": {"Bearer secret"},
+				"Proxy-Connection":    {"keep-alive"},
+				"Te":                  {"trailers"},
+				"Trailer":             {"Expires"},
+				"Transfer-Encoding":   {"chunked"},
+				"Upgrade":             {"websocket"},
+			},
+			want: http.Header{},
+		},
+		{
+			name: "removes_headers_named_by_connection",
+			header: http.Header{
+				"Connection":   {"keep-alive, X-Custom-Hop"},
+				"X-Custom-Hop": {"drop me"},
+			},
+			want: http.Header{},
+		},
+		{
+			name: "removes_headers_named_across_multiple_connection_values",
+			header: http.Header{
+				"Connection": {"X-First", "X-Second"},
+				"X-First":    {"drop me"},
+				"X-Second":   {"drop me too"},
+			},
+			want: http.Header{},
+		},
+		{
+			name: "keeps_end_to_end_headers",
+			header: http.Header{
+				"Connection":   {"keep-alive"},
+				"Content-Type": {"application/json"},
+				"Accept":       {"*/*"},
+				"X-Real-Ip":    {"127.0.0.1"},
+			},
+			want: http.Header{
+				"Content-Type": {"application/json"},
+				"Accept":       {"*/*"},
+				"X-Real-Ip":    {"127.0.0.1"},
+			},
+		},
+		{
+			name:   "no_connection_header_is_a_no_op",
+			header: http.Header{"Content-Type": {"text/html"}},
+			want:   http.Header{"Content-Type": {"text/html"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			delHopByHopHeaders(tt.header)
+			assert.Equal(t, tt.want, tt.header)
+		})
+	}
+}
+
+func TestProxy_proxyHandler_StripsHopByHopRequestHeaders(t *testing.T) {
+	var upstream http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		upstream = r.Header.Clone()
+	}))
+	defer srv.Close()
+
+	srvPort := getServerPort(t, srv)
+	proxy := NewProxy(&cfgProxy{
+		Enabled:   true,
+		ProxyPort: proxyPort,
+		AppPort:   srvPort,
+	})
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("http://localhost:%d", proxyPort), nil)
+	req.Header.Set("Connection", "keep-alive, X-Custom-Hop")
+	req.Header.Set("X-Custom-Hop", "should not reach the app")
+	req.Header.Set("Proxy-Authorization", "Bearer secret")
+	req.Header.Set("Keep-Alive", "timeout=5")
+	req.Header.Set("X-Real-Header", "should reach the app")
+	proxy.proxyHandler(httptest.NewRecorder(), req)
+
+	require.NotNil(t, upstream)
+	for _, name := range []string{"X-Custom-Hop", "Proxy-Authorization", "Keep-Alive"} {
+		assert.Empty(t, upstream.Get(name), "%s must not be forwarded upstream", name)
+	}
+	// End-to-end headers must still make it through.
+	assert.Equal(t, "should reach the app", upstream.Get("X-Real-Header"))
+}
+
+func TestProxy_proxyHandler_StripsHopByHopResponseHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Connection", "X-Custom-Hop")
+		w.Header().Set("X-Custom-Hop", "should not reach the client")
+		w.Header().Set("Keep-Alive", "timeout=5")
+		w.Header().Set("X-Real-Header", "should reach the client")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	srvPort := getServerPort(t, srv)
+	proxy := NewProxy(&cfgProxy{
+		Enabled:   true,
+		ProxyPort: proxyPort,
+		AppPort:   srvPort,
+	})
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("http://localhost:%d", proxyPort), nil)
+	rec := httptest.NewRecorder()
+	proxy.proxyHandler(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close()
+	for _, name := range []string{"X-Custom-Hop", "Keep-Alive"} {
+		assert.Empty(t, resp.Header.Get(name), "%s must not be returned to the client", name)
+	}
+	assert.Equal(t, "should reach the client", resp.Header.Get("X-Real-Header"))
+}
+
 func TestProxy_appStartTimeout(t *testing.T) {
 	tests := []struct {
 		name            string


### PR DESCRIPTION
## Summary

The dev proxy copied every incoming request header straight through to the app, and every upstream response header straight back to the client. Connection-specific headers must be consumed by the proxy instead (RFC 7230 section 6.1).

Fixes #933

## Changes

- Add `hopByHopHeaders` (`Connection`, `Keep-Alive`, `Proxy-Authenticate`, `Proxy-Authorization`, `Proxy-Connection`, `TE`, `Trailer`, `Transfer-Encoding`, `Upgrade`) and `delHopByHopHeaders()` in `runner/proxy.go`. Headers named by `Connection` are dropped before `Connection` itself, otherwise there is nothing left to read the names from.
- Filter the request headers before forwarding to the app.
- Filter the response headers on the way back to the client. The filtering is applied to the outgoing header map rather than `resp.Header`, so `isStreamingResponse` still sees the original `Transfer-Encoding`.
- Add `TestDelHopByHopHeaders` (table-driven, 5 cases) plus one integration test per direction. Both include negative cases asserting that end-to-end headers still pass through, so the tests cannot be satisfied by simply dropping everything.

I kept this to the header filtering only. Rewriting the handler on top of `httputil.ReverseProxy` would get this behaviour for free along with WebSocket support, but that is a much larger change and belongs in its own PR.

## Testing

```bash
go test ./runner/ -run 'HopByHop|TestProxy_proxyHandler' -v
go build ./... && go vet ./runner/
```

Both new integration tests were confirmed to fail when the two `delHopByHopHeaders` calls are removed, so they genuinely cover the fix.

Note: `TestRebuildWhenRunCmdUsingDLV` fails in the full `go test ./runner/` run on my machine, but it fails identically on `master` (it times out waiting for a port without `dlv` installed) and is unrelated to this change.

## Screenshots

N/A

## Checklist

- [x] Tests pass
- [x] Documentation updated (n/a, no user-facing config or behaviour change)
- [x] No breaking changes