### PR TITLE
ci: pin actions to commit SHAs and scope workflow permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:
@@ -72,6 +75,9 @@ jobs:
     name: Push master code to docker latest image
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # push the ghcr.io/air-verse/air image with GITHUB_TOKEN
     steps:
       # Without a checkout, build-push-action builds from the remote Git
       # context, which has no .git directory, so `git describe --tags` inside

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Setup Go
         id: go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ^1.25
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           # Build golangci-lint from source with the configured Go version
           install-mode: goinstall
@@ -35,7 +35,7 @@ jobs:
           CI: "true"
         run: go install github.com/go-delve/delve/cmd/dlv@latest && go test ./... -v -timeout=5m -covermode=count -coverprofile=coverage.txt
       - name: Upload Coverage report to CodeCov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.txt
@@ -46,7 +46,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Normalize line endings (Windows)
         if: runner.os == 'Windows'
         run: |
@@ -55,11 +55,11 @@ jobs:
           git checkout-index -f -a
       - name: Setup Go
         id: go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ^1.25
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           install-mode: goinstall
           version: latest
@@ -77,27 +77,27 @@ jobs:
       # context, which has no .git directory, so `git describe --tags` inside
       # the image cannot stamp a version. Fetch tags for the same reason.
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Normalize line endings (Windows)
         if: runner.os == 'Windows'
         run: |
@@ -20,7 +20,7 @@ jobs:
           git config core.eol lf
           git checkout-index -f -a
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ^1.25
 
@@ -32,7 +32,7 @@ jobs:
         run: echo ${{ env.GOVERSION }} ${{ env.VERSION }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5.1.0
         with:
           distribution: goreleaser
           version: latest
@@ -41,17 +41,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Push to DockerHub
         id: docker_build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           push: true
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,10 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ^1.25
+          # Don't restore a cache in the job that builds the published
+          # binaries: caches are writable from other workflow runs, so the
+          # release build should fetch modules from source.
+          cache: false
 
       - name: Set GOVERSION
         run: echo "GOVERSION=$(go version | sed -r 's/go version go(.*)\ .*/\1/')" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,16 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write # GoReleaser creates the GitHub release and uploads assets
     steps:
       - name: Check out code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   smoke_test_ubuntu:
     uses: ./.github/workflows/smoke_test_reuse_job.yml

--- a/.github/workflows/smoke_test_reuse_job.yml
+++ b/.github/workflows/smoke_test_reuse_job.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ inputs.run_on }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Normalize line endings (Windows)
         if: runner.os == 'Windows'
         run: |
@@ -22,11 +22,11 @@ jobs:
           git checkout-index -f -a
       - name: Setup Go
         id: go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ^1.25
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           install-mode: goinstall
           version: latest
@@ -78,7 +78,7 @@ jobs:
             "value=FAIL" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
           }
           if ($process -and -not $process.HasExited) { $process.Kill() }
-      - uses: nick-invision/assert-action@v2
+      - uses: nick-invision/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2.0.0
         with:
           expected: "PASS"
           actual: ${{ steps.check_rebuild_unix.outputs.value || steps.check_rebuild_windows.outputs.value }}

--- a/.github/workflows/smoke_test_reuse_job.yml
+++ b/.github/workflows/smoke_test_reuse_job.yml
@@ -7,6 +7,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   smoke_test:
     name: Smoke test

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
         with:
           stale-issue-message: 'This issue is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           stale-pr-message: "This PR is stale because it has had no activity for 180 days..."


### PR DESCRIPTION
Hi, drive-by CI hardening in three commits, one logical change each.

**Commit 1 pins every action to its commit sha**, versions kept as comments. A tag like `@v3` is a movable pointer: whoever controls the action, or anyone who compromises it, can re-point it and your next run executes their code with the job's credentials. The spots that matter here: `build.yml` pushes `cosmtrek/air:latest` and the ghcr image on every push to master while holding the Docker Hub token, and `release.yml` runs GoReleaser with a contents-scoped token plus the Docker Hub push for tagged releases. A re-pointed tag in either job means a poisoned image or release binary shipped under your name. Same pattern as the tj-actions/changed-files incident (CVE-2025-30066).

One line deserves a specific mention: `nick-invision/assert-action` in the smoke test only resolves through a redirect these days, the author renamed to nick-fields. Redirects like that are how repo-jacking happens: if the old name ever gets re-registered, a tag ref silently resolves to whatever the new owner published, while a sha pin fails closed instead of running substituted code.

You already went this direction once when you pinned `gr2m/merge-schedule-action@v2` to `v2.7.0` (#815); shas finish the job. All shas were resolved from the upstream repos and cross checked against their release tags. The pins stay maintainable: a dependabot config with the `github-actions` ecosystem (the repo has none today, happy to add it here if you want) or renovate both understand sha pins and keep bumping them with the version comment in sync.

**Commit 2 scopes the GITHUB_TOKEN per workflow**, derived from what each job actually uses: everything drops to `contents: read`, except the docker job in `build.yml` which keeps `packages: write` (it logs in to GHCR with the token) and the release job which gets `contents: write` (GoReleaser creates the GitHub release). Docker Hub and Codecov use their own secrets, not the token. `stale.yml` already declares scoped permissions (nicely done) and only got the pin.

**Commit 3 turns off the Go module cache restore in the release job** (`cache: false` on setup-go). Actions caches are writable from other workflow runs, so the job that builds the binaries users download should fetch modules from source rather than trust a shared cache; go.sum still verifies everything either way. Release builds are rare enough that the extra download time does not matter.

One heads up: if the org uses an Actions allowlist in settings, patterns written against tags (like `owner/action@v3`) stop matching once refs are shas and workflows refuse to start. Entries need to be `owner/action@*` in that case.

Found with the Plumber CLI (https://github.com/getplumber/plumber), verified on master. I also opened https://github.com/air-verse/air/pull/936 which adds it to CI so this does not quietly drift back, that one is a bonus, this PR stands on its own.