### PR TITLE
ci: add Plumber workflow security check

### DIFF
--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -1,0 +1,36 @@
+name: Plumber
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  plumber:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+      # Needed by score-push to publish the score for the README badge.
+      id-token: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+
+      - name: Run Plumber
+        uses: getplumber/plumber@40bd6b5bb8ff4f0944feacaeb41dea6bce08d62d # v0.4.28
+        with:
+          # Code scanning upload needs security-events write, which PRs
+          # from forks do not get. The report stays available as a
+          # workflow artifact there.
+          upload-sarif: ${{ github.event.pull_request.head.repo.fork != true }}
+          # Publishes the score to score.getplumber.io, which feeds the
+          # badge in the README. A failed push never fails the run.
+          score-push: true
+          # Gate at 85 points instead of the all-or-nothing default,
+          # leaves room for a small finding without blocking PRs.
+          min-points: 85

--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -1,0 +1,20 @@
+# Plumber overlay: inherits every control from the CLI's built-in
+# baseline, only the differences for this repo are written here.
+# Run 'plumber config resolve' to see the full effective config.
+extends: plumber:default
+version: "2.0"
+
+github:
+  controls:
+    githubActionMustComeFromAuthorizedSources:
+      # Keep the curated default list and trust the assert action the
+      # smoke test already uses on top of it.
+      includePlumberDefaults: true
+      trustedGithubActions:
+        - nick-invision/assert-action
+
+    # Off for now: master has no protection rules, which is a repository
+    # settings choice, not something a PR can change. Enable this once
+    # branch protection is on.
+    branchMustBeProtected:
+      enabled: false

--- a/README-ja.md
+++ b/README-ja.md
@@ -7,6 +7,7 @@
 [![Go](https://github.com/air-verse/air/actions/workflows/release.yml/badge.svg)](https://github.com/air-verse/air/actions?query=workflow%3AGo+branch%3Amaster)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/dcb95264cc504cad9c2a3d8b0795a7f8)](https://www.codacy.com/gh/air-verse/air/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=air-verse/air&amp;utm_campaign=Badge_Grade)
 [![codecov](https://codecov.io/gh/air-verse/air/branch/master/graph/badge.svg)](https://codecov.io/gh/air-verse/air)
+[![Plumber Score](https://score.getplumber.io/github.com/air-verse/air.svg)](https://score.getplumber.io/github.com/air-verse/air)
 
 [English](README.md) | [简体中文](README-zh_cn.md) | [繁體中文](README-zh_tw.md) | 日本語
 

--- a/README-zh_cn.md
+++ b/README-zh_cn.md
@@ -7,6 +7,7 @@
 [![Go](https://github.com/air-verse/air/actions/workflows/release.yml/badge.svg)](https://github.com/air-verse/air/actions?query=workflow%3AGo+branch%3Amaster)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/dcb95264cc504cad9c2a3d8b0795a7f8)](https://www.codacy.com/gh/air-verse/air/dashboard?utm_source=github.com&utm_medium=referral&utm_content=air-verse/air&utm_campaign=Badge_Grade)
 [![codecov](https://codecov.io/gh/air-verse/air/branch/master/graph/badge.svg)](https://codecov.io/gh/air-verse/air)
+[![Plumber Score](https://score.getplumber.io/github.com/air-verse/air.svg)](https://score.getplumber.io/github.com/air-verse/air)
 
 [English](README.md) | 简体中文 | [繁體中文](README-zh_tw.md) | [日本語](README-ja.md)
 

--- a/README-zh_tw.md
+++ b/README-zh_tw.md
@@ -7,6 +7,7 @@
 [![Go](https://github.com/air-verse/air/actions/workflows/release.yml/badge.svg)](https://github.com/air-verse/air/actions?query=workflow%3AGo+branch%3Amaster)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/dcb95264cc504cad9c2a3d8b0795a7f8)](https://www.codacy.com/gh/air-verse/air/dashboard?utm_source=github.com&utm_medium=referral&utm_content=air-verse/air&utm_campaign=Badge_Grade)
 [![codecov](https://codecov.io/gh/air-verse/air/branch/master/graph/badge.svg)](https://codecov.io/gh/air-verse/air)
+[![Plumber Score](https://score.getplumber.io/github.com/air-verse/air.svg)](https://score.getplumber.io/github.com/air-verse/air)
 
 [English](README.md) | [简体中文](README-zh_cn.md) | 繁體中文 | [日本語](README-ja.md)
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Go](https://github.com/air-verse/air/actions/workflows/release.yml/badge.svg)](https://github.com/air-verse/air/actions?query=workflow%3AGo+branch%3Amaster)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/dcb95264cc504cad9c2a3d8b0795a7f8)](https://www.codacy.com/gh/air-verse/air/dashboard?utm_source=github.com&utm_medium=referral&utm_content=air-verse/air&utm_campaign=Badge_Grade)
 [![codecov](https://codecov.io/gh/air-verse/air/branch/master/graph/badge.svg)](https://codecov.io/gh/air-verse/air)
+[![Plumber Score](https://score.getplumber.io/github.com/air-verse/air.svg)](https://score.getplumber.io/github.com/air-verse/air)
 
 English | [简体中文](README-zh_cn.md) | [繁體中文](README-zh_tw.md) | [日本語](README-ja.md)
 


### PR DESCRIPTION
Companion to https://github.com/air-verse/air/pull/935, merge that one first: the check added here flags the unpinned actions and the missing permission scopes until the hardening lands, then it goes green.

This adds [Plumber](https://github.com/getplumber/plumber) to CI, the tool I used to find those issues in the first place. It scans the workflows on each push to master and on each PR, and fails when something regresses: an unpinned action, a job without a permissions block, a known CVE, that kind of thing. The gate passes at 85 points, so one small finding does not block your PRs.

- `plumber.yml`: pinned by sha, minimal permissions, findings go to the security tab as SARIF (skipped on PRs from forks, the report stays as an artifact there).
- `.plumber.yaml`: a 20 line overlay that inherits the CLI's built-in baseline, you only see what differs for this repo: the assert action the smoke test uses is trusted on top of the curated default list, and the branch protection control is off with a comment saying why (master currently has no protection rules; that is a settings switch a PR cannot flip. If you enable protection on master some day, delete those four lines and the control takes over). Everything else, including new controls in future releases, follows the defaults automatically.
- README badge: one line, added to all four READMEs per the sync rule in AGENTS.md.

## Score badge

I enabled `score-push` on the action. It works like OpenSSF Scorecard's published results: every run, on any branch, publishes the score to score.getplumber.io, and that feeds the badge in the README. Scores are public and the badge always shows the state of master. A failed publish never fails your CI. Until the first run the badge reads UNKNOWN in gray, then it flips to the grade. If you would rather not have it, drop the README lines and the `score-push` input, the rest works the same.

With the hardening in, this runs green with a score of A. Set `soft-fail: true` if you prefer report only, without gating PRs.

To be fully transparent: I work on Plumber. If you do not want the tool in your CI, no hard feelings, the hardening PR is the one that matters and it stands on its own.