### PR TITLE
fix: stream and bounds build command output

### DIFF
--- a/runner/engine.go
+++ b/runner/engine.go
@@ -674,25 +674,32 @@ func (e *Engine) runCommand(command string) error {
 }
 
 func (e *Engine) runCommandCopyOutput(command string) (string, error) {
-	// both stdout and stderr are piped to the same buffer, so ignore the second
-	// one
-	cmd, stdout, _, err := e.startCmd(command)
+	cmd, stdout, stderr, err := e.startCmdWithCapture(command)
 	if err != nil {
 		return "", err
 	}
 	defer func() {
 		stdout.Close()
+		stderr.Close()
 	}()
 
-	stdoutBytes, _ := io.ReadAll(stdout)
-	_, _ = io.Copy(os.Stdout, strings.NewReader(string(stdoutBytes)))
+	var captured tailBuffer
+
+	stderrDone := make(chan struct{})
+	go func() {
+		defer close(stderrDone)
+		_, _ = io.Copy(io.MultiWriter(os.Stderr, &captured), stderr)
+	}()
+
+	_, _ = io.Copy(io.MultiWriter(os.Stdout, &captured), stdout)
+	<-stderrDone
 
 	// wait for command to finish
 	err = cmd.Wait()
 	if err != nil {
-		return string(stdoutBytes), err
+		return captured.String(), err
 	}
-	return string(stdoutBytes), nil
+	return captured.String(), nil
 }
 
 // run cmd option in .air.toml

--- a/runner/engine_capture_test.go
+++ b/runner/engine_capture_test.go
@@ -1,0 +1,66 @@
+package runner
+
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// silenceStdoutStderr points the process-wide streams at os.DevNull so tests
+// that copy large command output don't flood CI logs. The swap is restored on
+// cleanup. Tests using it must not call t.Parallel(): os.Stdout and os.Stderr
+// are process-wide, so a parallel test would see the swapped values.
+func silenceStdoutStderr(t *testing.T) {
+	t.Helper()
+	devnull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	require.NoError(t, err)
+	oldOut, oldErr := os.Stdout, os.Stderr
+	os.Stdout = devnull
+	os.Stderr = devnull
+	t.Cleanup(func() {
+		os.Stdout = oldOut
+		os.Stderr = oldErr
+		require.NoError(t, devnull.Close())
+	})
+}
+
+// newCaptureTestEngine builds a default-config engine rooted in a temp dir.
+func newCaptureTestEngine(t *testing.T) *Engine {
+	t.Helper()
+	chdir(t, t.TempDir())
+	e, err := NewEngine("", nil, true)
+	require.NoError(t, err)
+	return e
+}
+
+func TestRunCommandCopyOutputCapturesBoundedTail(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix shell syntax; windows runs commands through powershell")
+	}
+	e := newCaptureTestEngine(t)
+	silenceStdoutStderr(t)
+
+	out, err := e.runCommandCopyOutput(`sh -c 'seq 1 200000; echo END_MARKER; exit 1'`)
+	require.Error(t, err)
+	assert.NotEmpty(t, out)
+	assert.LessOrEqual(t, len(out), maxCapturedOutputSize)
+	assert.Contains(t, out, "END_MARKER")
+	// seq emits every integer exactly once, so a standalone line "1" only
+	// exists at the head of the stream; its absence proves the oldest bytes
+	// were dropped in favor of the tail.
+	assert.NotContains(t, out, "\n1\n")
+}
+
+func TestRunCommandCopyOutputSmallSuccess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix shell syntax; windows runs commands through powershell")
+	}
+	e := newCaptureTestEngine(t)
+
+	out, err := e.runCommandCopyOutput(`echo hello-capture`)
+	require.NoError(t, err)
+	assert.Equal(t, "hello-capture\n", out)
+}

--- a/runner/engine_test.go
+++ b/runner/engine_test.go
@@ -1388,6 +1388,10 @@ func Test(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Mute logging: runBin reports process exits from a detached goroutine
+	// that no teardown can join, and its fatih/color access would race with
+	// later tests that swap color globals.
+	engine.config.Log.Silent = true
 	go func() {
 		engine.Run()
 	}()
@@ -1399,7 +1403,7 @@ func Test(t *testing.T) {
 		t.Fatal(err)
 	}
 	go func() {
-		file, err = os.OpenFile("main_test.go", os.O_APPEND|os.O_WRONLY, 0o644)
+		file, err := os.OpenFile("main_test.go", os.O_APPEND|os.O_WRONLY, 0o644)
 		assert.NoError(t, err)
 		defer file.Close()
 		_, err = file.WriteString("\n")
@@ -1407,6 +1411,14 @@ func Test(t *testing.T) {
 	}()
 	// should Have rebuild
 	if err = waitingPortReady(t, port, time.Second*10); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stop the engine and wait for a full teardown so its goroutines don't
+	// outlive the test and race later tests that mutate package-level
+	// state such as color globals.
+	engine.Stop()
+	if err := waitForEngineState(t, engine, false, time.Second*5); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -1483,6 +1495,10 @@ include_file = ["main.sh"]
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Mute logging: runBin reports process exits from a detached goroutine
+	// that no teardown can join, and its fatih/color access would race with
+	// later tests that swap color globals.
+	engine.config.Log.Silent = true
 	go func() {
 		engine.Run()
 	}()
@@ -1510,6 +1526,14 @@ include_file = ["main.sh"]
 		t.Fatal(err)
 	}
 	assert.Equal(t, []byte("modified"), bytes)
+
+	// Stop the engine and wait for a full teardown so its goroutines don't
+	// outlive the test and race later tests that mutate package-level
+	// state such as color globals.
+	engine.Stop()
+	if err := waitForEngineState(t, engine, false, time.Second*5); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestShouldIncludeIncludedFileWithoutIncludedExt(t *testing.T) {
@@ -1546,6 +1570,10 @@ include_file = ["main.sh"]
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Mute logging: runBin reports process exits from a detached goroutine
+	// that no teardown can join, and its fatih/color access would race with
+	// later tests that swap color globals.
+	engine.config.Log.Silent = true
 	go func() {
 		engine.Run()
 	}()
@@ -1560,7 +1588,7 @@ include_file = ["main.sh"]
 
 	t.Logf("start change main.sh")
 	go func() {
-		err = os.WriteFile("main.sh", []byte("#!/bin/sh\nprintf modified > output"), 0o755)
+		err := os.WriteFile("main.sh", []byte("#!/bin/sh\nprintf modified > output"), 0o755)
 		if err != nil {
 			log.Fatalf("Error updating file: %s.", err)
 		}
@@ -1573,6 +1601,14 @@ include_file = ["main.sh"]
 		t.Fatal(err)
 	}
 	assert.Equal(t, []byte("modified"), bytes)
+
+	// Stop the engine and wait for a full teardown so its goroutines don't
+	// outlive the test and race later tests that mutate package-level
+	// state such as color globals.
+	engine.Stop()
+	if err := waitForEngineState(t, engine, false, time.Second*5); err != nil {
+		t.Fatal(err)
+	}
 }
 
 type testExiter struct {

--- a/runner/logger_test.go
+++ b/runner/logger_test.go
@@ -8,7 +8,8 @@ import (
 )
 
 func TestLogFuncWritesToStderr(t *testing.T) {
-	t.Parallel()
+	// Not parallel: this test swaps the process-wide os.Stdout and os.Stderr
+	// globals, so a parallel sibling reading them via fmt.Print would race.
 
 	// Capture stderr
 	oldStderr := os.Stderr

--- a/runner/util.go
+++ b/runner/util.go
@@ -25,6 +25,8 @@ const (
 	sliceCmdArgSeparator = ","
 	// extWildcard is used in include_ext to match all file extensions
 	extWildcard = "*"
+	// keep last 64KiB for build failure overlay
+	maxCapturedOutputSize = 64 << 10
 )
 
 func (e *Engine) mainLog(format string, v ...interface{}) {
@@ -595,4 +597,25 @@ func isDangerousRoot(path string) (bool, string) {
 	}
 
 	return false, ""
+}
+
+type tailBuffer struct {
+	mu  sync.Mutex
+	buf []byte
+}
+
+func (t *tailBuffer) Write(p []byte) (int, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.buf = append(t.buf, p...)
+	if overflow := len(t.buf) - maxCapturedOutputSize; overflow > 0 {
+		t.buf = t.buf[overflow:]
+	}
+	return len(p), nil
+}
+
+func (t *tailBuffer) String() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return string(t.buf)
 }

--- a/runner/util_linux.go
+++ b/runner/util_linux.go
@@ -55,7 +55,7 @@ func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 	}
 }
 
-func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
+func (e *Engine) startCmdWithOptions(cmd string, capture bool) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
 	c := exec.Command("/bin/sh", "-c", cmd)
 	// Set Setpgid to create a new process group (not possible when using pty)
 	c.SysProcAttr = &syscall.SysProcAttr{
@@ -71,14 +71,24 @@ func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, 
 		return nil, nil, nil, err
 	}
 
-	c.Stdout = os.Stdout
-	c.Stderr = os.Stderr
+	if !capture {
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stderr
+	}
 
 	err = c.Start()
 	if err != nil {
 		return nil, nil, nil, err
 	}
 	return c, stdout, stderr, nil
+}
+
+func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
+	return e.startCmdWithOptions(cmd, false) // backward compatible
+}
+
+func (e *Engine) startCmdWithCapture(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
+	return e.startCmdWithOptions(cmd, true)
 }
 
 func sendSignalToProcessTree(pid int, sig syscall.Signal) error {

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1249,4 +1250,58 @@ func TestExpandPathRootDirectoryIsSymlink(t *testing.T) {
 	if gotPath != expectedPath {
 		t.Errorf("expandPath failed to correctly resolve the symlinked directory.\nGot:  %s\nWant: %s", gotPath, expectedPath)
 	}
+}
+
+func TestTailBuffer(t *testing.T) {
+	t.Run("keeps everything under the cap", func(t *testing.T) {
+		var buf tailBuffer
+		n, err := buf.Write([]byte("hello world"))
+		require.NoError(t, err)
+		assert.Equal(t, 11, n)
+		assert.Equal(t, "hello world", buf.String())
+	})
+
+	t.Run("keeps exactly the cap", func(t *testing.T) {
+		var buf tailBuffer
+		payload := strings.Repeat("a", maxCapturedOutputSize)
+		_, err := buf.Write([]byte(payload))
+		require.NoError(t, err)
+		assert.Equal(t, payload, buf.String())
+	})
+
+	t.Run("drops the head when a single write exceeds the cap", func(t *testing.T) {
+		var buf tailBuffer
+		payload := strings.Repeat("a", maxCapturedOutputSize) + "TAIL"
+		_, err := buf.Write([]byte(payload))
+		require.NoError(t, err)
+		expectedTail := strings.Repeat("a", maxCapturedOutputSize-len("TAIL")) + "TAIL"
+		got := buf.String()
+		assert.Len(t, got, maxCapturedOutputSize)
+		assert.Equal(t, expectedTail, got)
+	})
+
+	t.Run("drops the oldest bytes across incremental writes", func(t *testing.T) {
+		var buf tailBuffer
+		_, err := buf.Write([]byte("123456"))
+		require.NoError(t, err)
+		_, err = buf.Write([]byte(strings.Repeat("x", maxCapturedOutputSize)))
+		require.NoError(t, err)
+		assert.Equal(t, strings.Repeat("x", maxCapturedOutputSize), buf.String())
+	})
+
+	t.Run("stays bounded under concurrent writers", func(t *testing.T) {
+		var buf tailBuffer
+		var wg sync.WaitGroup
+		for i := 0; i < 8; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 100; j++ {
+					_, _ = buf.Write([]byte("0123456789abcdef"))
+				}
+			}()
+		}
+		wg.Wait()
+		assert.LessOrEqual(t, len(buf.String()), maxCapturedOutputSize)
+	})
 }

--- a/runner/util_unix.go
+++ b/runner/util_unix.go
@@ -54,7 +54,7 @@ func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 	}
 }
 
-func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
+func (e *Engine) startCmdWithOptions(cmd string, capture bool) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
 	c := exec.Command("/bin/sh", "-c", cmd)
 	// because using pty cannot have same pgid
 	c.SysProcAttr = &syscall.SysProcAttr{
@@ -70,12 +70,22 @@ func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, 
 		return nil, nil, nil, err
 	}
 
-	c.Stdout = os.Stdout
-	c.Stderr = os.Stderr
+	if !capture {
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stderr
+	}
 
 	err = c.Start()
 	if err != nil {
 		return nil, nil, nil, err
 	}
 	return c, stdout, stderr, nil
+}
+
+func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
+	return e.startCmdWithOptions(cmd, false) // backward compatible
+}
+
+func (e *Engine) startCmdWithCapture(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
+	return e.startCmdWithOptions(cmd, true)
 }

--- a/runner/util_windows.go
+++ b/runner/util_windows.go
@@ -40,7 +40,7 @@ func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 	return pid, err
 }
 
-func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
+func (e *Engine) startCmdWithOptions(cmd string, capture bool) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
 	var err error
 
 	if !strings.Contains(cmd, ".exe") {
@@ -60,12 +60,22 @@ func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, 
 		return nil, nil, nil, err
 	}
 
-	c.Stdout = os.Stdout
-	c.Stderr = os.Stderr
+	if !capture {
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stderr
+	}
 
 	err = c.Start()
 	if err != nil {
 		return nil, nil, nil, err
 	}
 	return c, stdout, stderr, err
+}
+
+func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
+	return e.startCmdWithOptions(cmd, false) // backward compatible
+}
+
+func (e *Engine) startCmdWithCapture(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
+	return e.startCmdWithOptions(cmd, true)
 }


### PR DESCRIPTION
Fixes: https://github.com/air-verse/air/issues/932

## Summary
The proxy build-failure overlay always showed an empty Output section:
startCmd created StdoutPipe/StderrPipe but immediately overwrote
Cmd.Stdout/Stderr with terminal fds, orphaning the pipes so
io.ReadAll captured "" every time.

## Changes
- startCmdWithOptions(capture bool) across linux/unix/windows; legacy
  startCmd untouched for pre/post cmds 
- runCommandCopyOutput streams stdout+stderr live, capturing a merged
  bounded 64KiB tail (new tailBuffer) for BuildFailedMsg
- tests: TestTailBuffer + bounded-capture integration test
- includes a separate first commit fixing pre-existing -race flakes that
  blocked verification of this change

## Testing
- go test ./... -race -timeout=3m ✅ 
- make check scope=all ✅
- Manual e2e: forced compile failure now renders compiler output in the overlay; seq 1 200000 stays ≤64KiB with tail retention while streaming live.

## Working Proof (for proxy overlay missing output)
- empty overlay output section(existing):
<img width="857" height="599" alt="Screenshot From 2026-08-25 13-28-40" src="https://github.com/user-attachments/assets/5686a4d7-2ee3-4226-863a-a5d96b56ea7d" />
- showing terminal output/compile error in output section(fixed/expected):
<img width="1714" height="655" alt="image" src="https://github.com/user-attachments/assets/025e5090-eb64-4877-98d8-8bd77eedca52" />
