### PR TITLE
chore: update Dockerfile to Go 1.27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26 AS builder
+FROM golang:1.27 AS builder
 
 LABEL maintainer="Rick Yu <cosmtrek@gmail.com>"
 
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/go/pkg/mod go mod download
 
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build make ci && make install
 
-FROM golang:1.26
+FROM golang:1.27
 
 COPY --from=builder /go/bin/air  /go/bin/air
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LDFLAGS += -X "main.airVersion=$(AIRVER)"
 LDFLAGS += -X "main.goVersion=$(shell go version | sed -r 's/go version go(.*)\ .*/\1/')"
 
 GO := GO111MODULE=on CGO_ENABLED=0 go
-GOLANGCI_LINT_VERSION = v2.6.1
+GOLANGCI_LINT_VERSION = v2.13.1
 GOLANGCI_LINT_CURRENT := $(shell golangci-lint --version 2>/dev/null | sed -n 's/.*version \([0-9.]*\).*/v\1/p')
 
 .PHONY: init


### PR DESCRIPTION
Addresses #939 .

Testing:
`make docker-image` ran successfully.